### PR TITLE
2주차 구현사항 반영

### DIFF
--- a/lib/view/alarm_screen.dart
+++ b/lib/view/alarm_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class AlarmScreen extends StatelessWidget {
+  const AlarmScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("알람 화면"),
+      ),
+      body: Center(
+        child: Text("알람 화면"),
+      ),
+    );
+  }
+}

--- a/lib/view/evaluate_screen.dart
+++ b/lib/view/evaluate_screen.dart
@@ -23,14 +23,14 @@ class _evalute_screenState extends State<evaluate_screen> {
     super.initState();
     //새로운 api 형식에 따라 넣어뒀음. class lecture에 하나하나씩 차곡차곡 쌓이게 작업해뒀고,
     //그중 가장 첫번째 데이터를 정리해서 print로 출력하였으니 참고바람.
-    // WidgetsBinding.instance.addPostFrameCallback((_) async {
-    //   _lecture_list = (await fetchData('데이터베이스', '컴퓨터공학과'))!;
-    //   setState(() {});
-    // });
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      _lecture_list = (await fetchData('데이터베이스', '컴퓨터공학과'))!;
+      setState(() {});
+    });
   }
 
   // component/fetch_data에서 가져온 데이터를 return해서 lits를 evaluate_screen에서 받아줌.
-  // late List<Lecture> _lecture_list;
+  late List<Lecture> _lecture_list;
 
   //값에 따라 강의평 홈 / 강의평 검색 / 강의평 추가 화면 을 setState로 구별.
   //아래에 있는 bottomNaviagtorBar때문.

--- a/lib/view/main_screen.dart
+++ b/lib/view/main_screen.dart
@@ -14,14 +14,13 @@ class main_screen extends StatefulWidget {
 }
 
 class _main_screenState extends State<main_screen> {
-
   late List<GlobalKey<NavigatorState>> _navigatorKeyList;
 
   final _pages = [
     home_screen(),
     notice_screen(),
     evaluate_screen(),
-    point_screen(),
+    //point_screen(), // 현재 포인트 생략 상태
     mypage_screen(),
   ];
 
@@ -29,24 +28,27 @@ class _main_screenState extends State<main_screen> {
   void initState() {
     // TODO: implement initState
     super.initState();
-    _navigatorKeyList = List.generate(_pages.length, (index) => GlobalKey<NavigatorState>());
+    _navigatorKeyList =
+        List.generate(_pages.length, (index) => GlobalKey<NavigatorState>());
   }
 
   int _current_index = 0;
 
   @override
   Widget build(BuildContext context) {
-
     return WillPopScope(
       onWillPop: () async {
-        return !(await _navigatorKeyList[_current_index].currentState!.maybePop());
+        return !(await _navigatorKeyList[_current_index]
+            .currentState!
+            .maybePop());
       },
       child: Scaffold(
         resizeToAvoidBottomInset: false,
         body: Navigator(
           key: _navigatorKeyList[_current_index],
           onGenerateRoute: (_) {
-            return MaterialPageRoute(builder: (context) => _pages[_current_index]);
+            return MaterialPageRoute(
+                builder: (context) => _pages[_current_index]);
           },
         ),
         bottomNavigationBar: BottomNavigationBar(
@@ -69,10 +71,10 @@ class _main_screenState extends State<main_screen> {
               icon: Icon(Icons.library_books),
               label: '강의평가',
             ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.attach_money),
-              label: '포인트',
-            ),
+            // BottomNavigationBarItem(
+            //   icon: Icon(Icons.attach_money),
+            //   label: '포인트',
+            // ),
             BottomNavigationBarItem(
               icon: Icon(Icons.person),
               label: '마이',

--- a/lib/view/notice_screen.dart
+++ b/lib/view/notice_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:myapp/view/alarm_screen.dart';
+import 'package:myapp/view/notice_screen_detail.dart';
+import 'package:myapp/view/notice_screen_similar.dart';
 import '../component/announce_tag.dart';
 
 class notice_screen extends StatefulWidget {
@@ -44,7 +47,7 @@ Widget sss() {
                               return announce_tag_widget(index);
                             },
                             separatorBuilder: (context, index) {
-                              return SizedBox(width:4 ,height: 25);
+                              return SizedBox(width: 4, height: 25);
                             },
                           ))
                     ],
@@ -68,228 +71,437 @@ class _notice_screenState extends State<notice_screen> {
   int notice_screen_topic_num = 0;
   TextEditingController? _controller = TextEditingController(text: '');
 
+  final Map<String, Map<String, String>> _noticeData = {
+    '0': {
+      'title': '[현장실습] 2024-1학기 (주)세정 표준 현장실습학기제 참여 학생 모집(의상디자인, 상품MD)',
+      'category': '인턴십 💼',
+      'link': "http://www.naver.com",
+    },
+    '1': {
+      'title': '[현장실습] 2024-1학기 (주)세정 표준 현장실습학기제 참여 학생 모집(의상디자인, 상품MD)',
+      'category': '인턴십 💼',
+      'link': "http://www.naver.com",
+    },
+    '2': {
+      'title': '[현장실습] 2024-1학기 (주)세정 표준 현장실습학기제 참여 학생 모집(의상디자인, 상품MD)',
+      'category': '인턴십 💼',
+      'link': "http://www.naver.com",
+    },
+  };
+
+  final Map<String, Map<String, String>> _SimilarNoticeData = {
+    '0': {
+      'title': '[현장실습] 2024-1학기 (주)세정 표준 현장실습학기제 참여 학생 모집(의상디자인, 상품MD)',
+      'category': '인턴십 💼',
+      'link': "http://www.naver.com",
+    },
+    '1': {
+      'title': '[현장실습] 2024-1학기 (주)세정 표준 현장실습학기제 참여 학생 모집(의상디자인, 상품MD)',
+      'category': '인턴십 💼',
+      'link': "http://www.naver.com",
+    },
+    '2': {
+      'title': '[현장실습] 2024-1학기 (주)세정 표준 현장실습학기제 참여 학생 모집(의상디자인, 상품MD)',
+      'category': '인턴십 💼',
+      'link': "http://www.naver.com",
+    },
+  };
+
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
         FocusManager.instance.primaryFocus?.unfocus();
       },
-      child: Scaffold(
-          appBar: AppBar(
-            title: const Text(
-              'InfoU',
-              style: TextStyle(color: Colors.blueAccent),
+      child: MaterialApp(
+        theme: ThemeData(
+            scaffoldBackgroundColor: Color(0xFFF3F3F3), // 전체 배경 색상 설정
+            appBarTheme: AppBarTheme(
+              backgroundColor: Color(0xFFF3F3F3), // AppBar 배경 색상 설정
+            )),
+        home: Scaffold(
+            appBar: AppBar(
+              title: Text("공지사항"),
             ),
-            backgroundColor: Colors.white,
-          ),
-          resizeToAvoidBottomInset: false,
-          body: Container(
-            color: Colors.white,
-            width: MediaQuery.of(context).size.width,
-            height: MediaQuery.of(context).size.height,
-            child: Column(
-              children: [
-                //토픽
-                Stack(children: [
-                  Container(
-                    height: 30,
-                    child: Center(
-                      child: ListView.separated(
-                        shrinkWrap: true,
-                        separatorBuilder: (context, index) {
-                          return Text(
-                            '|',
-                            style: TextStyle(fontSize: 14),
-                          );
-                        },
-                        itemCount: announce_topic_name.length,
-                        scrollDirection: Axis.horizontal,
-                        itemBuilder: (context, index) {
-                          return GestureDetector(
-                            onTap: () {
-                              setState(() {
-                                notice_screen_topic_num = index;
-                              });
-                              print(index);
-                            },
-                            child: Padding(
-                              padding: EdgeInsets.fromLTRB(5, 0, 5, 0),
-                              child: Text(
-                                announce_topic_name[index],
-                                style: TextStyle(
-                                    fontSize: 14,
-                                    fontWeight:
-                                        (index == notice_screen_topic_num)
-                                            ? FontWeight.bold
-                                            : FontWeight.normal),
+            resizeToAvoidBottomInset: false,
+            body: SingleChildScrollView(
+              child: Container(
+                color: Color(0xFFF3F3F3),
+                width: MediaQuery.of(context).size.width,
+                height: MediaQuery.of(context).size.height,
+                child: Column(
+                  children: [
+                    Positioned(
+                      left: 15.99,
+                      top: 99,
+                      child: Container(
+                        width: MediaQuery.of(context).size.width * 0.9,
+                        padding: const EdgeInsets.only(
+                          top: 10,
+                          left: 6,
+                          right: 14,
+                          bottom: 10,
+                        ),
+                        decoration: ShapeDecoration(
+                          color: Colors.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          shadows: [
+                            BoxShadow(
+                              color: Color(0x3F000000),
+                              blurRadius: 4,
+                              offset: Offset(0, 4),
+                              spreadRadius: 0,
+                            )
+                          ],
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            Text(
+                              '🔔 모든 공지사항 조회 ',
+                              style: TextStyle(
+                                color: Colors.black,
+                                fontSize: 14,
+                                fontFamily: 'Inter',
+                                fontWeight: FontWeight.w700,
+                                height: 0,
                               ),
                             ),
-                          );
-                        },
+                          ],
+                        ),
                       ),
                     ),
-                  ),
-                  Align(
-                    alignment: Alignment.centerRight,
-                    child: Padding(
-                      padding: const EdgeInsets.fromLTRB(0, 2.5, 10, 0),
-                      child: GestureDetector(
-                          child: Text('추가하기',
-                              style: TextStyle(
-                                  color: Colors.black38,
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 11)),
-                          onTap: () {}),
-                    ),
-                  )
-                ]),
-                //검색창
-                Container(
-                    padding: EdgeInsets.fromLTRB(8, 0, 8, 0),
-                    decoration: BoxDecoration(
-                      color: Colors.grey.shade200,
-                      borderRadius: BorderRadius.circular(20),
-                    ),
-                    width: MediaQuery.of(context).size.width * 0.87,
-                    height: 35,
-                    margin: EdgeInsets.fromLTRB(0, 0, 0, 3),
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        Icon(Icons.search, size: 19),
-                        Expanded(
-                          child: Padding(
-                            padding: const EdgeInsets.fromLTRB(5, 0, 0, 0),
-                            child: TextField(
-                              controller: _controller,
-                              style: TextStyle(
-                                  fontSize: 15, fontWeight: FontWeight.bold),
-                              decoration: InputDecoration(
-                                  hintText: '검색어를 입력해주세요',
-                                  border: InputBorder.none,
-                                  hintStyle: TextStyle(color: Colors.black12)),
-                            ),
-                          ),
-                        ),
-                        GestureDetector(
-                            onTap: () {
-                              setState(() {
-                                print(1);
-                                _controller?.text = '';
-                                //포커스 해제
-                                FocusManager.instance.primaryFocus?.unfocus();
-                              });
-                            },
-                            child: Icon(Icons.cancel_outlined, size: 17)),
-                      ],
-                    )),
-                Container(
-                  height: 37,
-                  width: 400,
-                  child: Padding(
-                    padding: EdgeInsets.fromLTRB(23, 8, 0, 4),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        //index에 따라 api에서 가져온 값 넣어주면 됨.
-                        Expanded(
-                          child: ListView.builder(
-                            scrollDirection: Axis.horizontal,
-                            itemCount: 5,
-                            itemBuilder: (context, index) {
-                              return announce_tag_widget(index);
-                            },
-                          ),
-                        )
-                      ],
-                    ),
-                  ),
-                ),
-                Padding(
-                  padding: EdgeInsets.fromLTRB(20, 0, 20, 0),
-                  child: Divider(thickness: 1, color: Colors.grey),
-                ),
+                    SizedBox(height: 10),
 
-                //각각 widget 형성된걸로 넣어줌. 하나의 예시일뿐 api에 따라 listview처리 해줘야함.
-                //Container의 height, width, Expanded의 처리가 까다로움 주의.
-                sss(),
-                sss(),
-                //아래 빠르게 바로가기 코드입니다. 화살표에 따라 값 변경, 값 선택에 따른 내부 값 처리까지 다 해놨습니다.
-                Align(
-                  alignment: Alignment.bottomCenter,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      GestureDetector(
-                        onTap: () {
-                          setState(() {
-                            (min_list_num != 1) ? min_list_num-- : min_list_num;
-                          });
-                        },
-                        child: Text(
-                          '< ',
-                          style: TextStyle(
-                            fontSize: 20,
-                          ),
-                        ),
-                      ),
-                      Container(
-                        height: 35,
-                        width: 300,
-                        child: ListView.builder(
-                          scrollDirection: Axis.horizontal,
-                          itemCount: 9,
-                          itemBuilder: (context, index) {
-                            return Card(
-                              color: Colors.white,
-                              shadowColor: Colors.white,
-                              child: Container(
-                                color: Colors.white,
-                                width:
-                                    (MediaQuery.of(context).size.width - 30.4) *
-                                        0.069,
-                                child: GestureDetector(
-                                  onTap: () {
-                                    setState(() {
-                                      current_list_num =
-                                          index + min_list_num - 1;
-                                    });
-                                    print(index);
-                                  },
-                                  child: Text(
-                                    (min_list_num + index).toString(),
-                                    style: TextStyle(
-                                      fontSize: 20,
-                                      fontWeight: current_list_num ==
-                                              (min_list_num + index - 1)
-                                          ? FontWeight.bold
-                                          : FontWeight.normal,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            );
-                          },
-                        ),
-                      ),
-                      GestureDetector(
-                        onTap: () {
-                          setState(() {
-                            min_list_num++;
-                          });
-                        },
-                        child: Text(' >',
-                            style: TextStyle(
-                              fontSize: 20,
-                            )),
-                      ),
-                    ],
+                    // 즐겨찾기 항목
+                    noticeView(
+                        title: " 📔 즐겨찾기",
+                        noticeData: _noticeData,
+                        page: 'notice'), // 공지사항
+                    noticeView(
+                        title: " 📔 비슷한 사용자가 본 공지사항",
+                        noticeData: _SimilarNoticeData,
+                        page: 'similar'), // 공지사항
+
+                    //토픽
+                    // Stack(children: [
+                    //   Container(
+                    //     height: 30,
+                    //     child: Center(
+                    //       child: ListView.separated(
+                    //         shrinkWrap: true,
+                    //         separatorBuilder: (context, index) {
+                    //           return Text(
+                    //             '|',
+                    //             style: TextStyle(fontSize: 14),
+                    //           );
+                    //         },
+                    //         itemCount: announce_topic_name.length,
+                    //         scrollDirection: Axis.horizontal,
+                    //         itemBuilder: (context, index) {
+                    //           return GestureDetector(
+                    //             onTap: () {
+                    //               setState(() {
+                    //                 notice_screen_topic_num = index;
+                    //               });
+                    //               print(index);
+                    //             },
+                    //             child: Padding(
+                    //               padding: EdgeInsets.fromLTRB(5, 0, 5, 0),
+                    //               child: Text(
+                    //                 announce_topic_name[index],
+                    //                 style: TextStyle(
+                    //                     fontSize: 14,
+                    //                     fontWeight:
+                    //                         (index == notice_screen_topic_num)
+                    //                             ? FontWeight.bold
+                    //                             : FontWeight.normal),
+                    //               ),
+                    //             ),
+                    //           );
+                    //         },
+                    //       ),
+                    //     ),
+                    //   ),
+                    //   Align(
+                    //     alignment: Alignment.centerRight,
+                    //     child: Padding(
+                    //       padding: const EdgeInsets.fromLTRB(0, 2.5, 10, 0),
+                    //       child: GestureDetector(
+                    //           child: Text('추가하기',
+                    //               style: TextStyle(
+                    //                   color: Colors.black38,
+                    //                   fontWeight: FontWeight.bold,
+                    //                   fontSize: 11)),
+                    //           onTap: () {}),
+                    //     ),
+                    //   )
+                    // ]),
+                    // //검색창
+                    // Container(
+                    //     padding: EdgeInsets.fromLTRB(8, 0, 8, 0),
+                    //     decoration: BoxDecoration(
+                    //       color: Colors.grey.shade200,
+                    //       borderRadius: BorderRadius.circular(20),
+                    //     ),
+                    //     width: MediaQuery.of(context).size.width * 0.87,
+                    //     height: 35,
+                    //     margin: EdgeInsets.fromLTRB(0, 0, 0, 3),
+                    //     child: Row(
+                    //       crossAxisAlignment: CrossAxisAlignment.center,
+                    //       children: [
+                    //         Icon(Icons.search, size: 19),
+                    //         Expanded(
+                    //           child: Padding(
+                    //             padding: const EdgeInsets.fromLTRB(5, 0, 0, 0),
+                    //             child: TextField(
+                    //               controller: _controller,
+                    //               style: TextStyle(
+                    //                   fontSize: 15,
+                    //                   fontWeight: FontWeight.bold),
+                    //               decoration: InputDecoration(
+                    //                   hintText: '검색어를 입력해주세요',
+                    //                   border: InputBorder.none,
+                    //                   hintStyle:
+                    //                       TextStyle(color: Colors.black12)),
+                    //             ),
+                    //           ),
+                    //         ),
+                    //         GestureDetector(
+                    //             onTap: () {
+                    //               setState(() {
+                    //                 print(1);
+                    //                 _controller?.text = '';
+                    //                 //포커스 해제
+                    //                 FocusManager.instance.primaryFocus
+                    //                     ?.unfocus();
+                    //               });
+                    //             },
+                    //             child: Icon(Icons.cancel_outlined, size: 17)),
+                    //       ],
+                    //     )),
+                    // Container(
+                    //   height: 37,
+                    //   width: 400,
+                    //   child: Padding(
+                    //     padding: EdgeInsets.fromLTRB(23, 8, 0, 4),
+                    //     child: Row(
+                    //       mainAxisAlignment: MainAxisAlignment.center,
+                    //       crossAxisAlignment: CrossAxisAlignment.center,
+                    //       children: [
+                    //         //index에 따라 api에서 가져온 값 넣어주면 됨.
+                    //         Expanded(
+                    //           child: ListView.builder(
+                    //             scrollDirection: Axis.horizontal,
+                    //             itemCount: 5,
+                    //             itemBuilder: (context, index) {
+                    //               return announce_tag_widget(index);
+                    //             },
+                    //           ),
+                    //         )
+                    //       ],
+                    //     ),
+                    //   ),
+                    // ),
+                    // Padding(
+                    //   padding: EdgeInsets.fromLTRB(20, 0, 20, 0),
+                    //   child: Divider(thickness: 1, color: Colors.grey),
+                    // ),
+
+                    // //각각 widget 형성된걸로 넣어줌. 하나의 예시일뿐 api에 따라 listview처리 해줘야함.
+                    // //Container의 height, width, Expanded의 처리가 까다로움 주의.
+                    // sss(),
+                    // sss(),
+                    // //아래 빠르게 바로가기 코드입니다. 화살표에 따라 값 변경, 값 선택에 따른 내부 값 처리까지 다 해놨습니다.
+                    // Align(
+                    //   alignment: Alignment.bottomCenter,
+                    //   child: Row(
+                    //     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    //     children: [
+                    //       GestureDetector(
+                    //         onTap: () {
+                    //           setState(() {
+                    //             (min_list_num != 1)
+                    //                 ? min_list_num--
+                    //                 : min_list_num;
+                    //           });
+                    //         },
+                    //         child: Text(
+                    //           '< ',
+                    //           style: TextStyle(
+                    //             fontSize: 20,
+                    //           ),
+                    //         ),
+                    //       ),
+                    //       Container(
+                    //         height: 35,
+                    //         width: 300,
+                    //         child: ListView.builder(
+                    //           scrollDirection: Axis.horizontal,
+                    //           itemCount: 9,
+                    //           itemBuilder: (context, index) {
+                    //             return Card(
+                    //               color: Colors.white,
+                    //               shadowColor: Colors.white,
+                    //               child: Container(
+                    //                 color: Colors.white,
+                    //                 width: (MediaQuery.of(context).size.width -
+                    //                         30.4) *
+                    //                     0.069,
+                    //                 child: GestureDetector(
+                    //                   onTap: () {
+                    //                     setState(() {
+                    //                       current_list_num =
+                    //                           index + min_list_num - 1;
+                    //                     });
+                    //                     print(index);
+                    //                   },
+                    //                   child: Text(
+                    //                     (min_list_num + index).toString(),
+                    //                     style: TextStyle(
+                    //                       fontSize: 20,
+                    //                       fontWeight: current_list_num ==
+                    //                               (min_list_num + index - 1)
+                    //                           ? FontWeight.bold
+                    //                           : FontWeight.normal,
+                    //                     ),
+                    //                   ),
+                    //                 ),
+                    //               ),
+                    //             );
+                    //           },
+                    //         ),
+                    //       ),
+                    //       GestureDetector(
+                    //         onTap: () {
+                    //           setState(() {
+                    //             min_list_num++;
+                    //           });
+                    //         },
+                    //         child: Text(' >',
+                    //             style: TextStyle(
+                    //               fontSize: 20,
+                    //             )),
+                    //       ),
+                    //     ],
+                    //   ),
+                    // )
+                  ],
+                ),
+              ),
+            )),
+      ),
+    );
+  }
+}
+
+class noticeView extends StatelessWidget {
+  final Map<String, Map<String, String>> noticeData;
+  final String title;
+  final String page;
+
+  const noticeView({
+    Key? key,
+    required this.noticeData,
+    required this.title,
+    required this.page,
+  }) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.only(bottom: 10),
+      width: MediaQuery.of(context).size.width * 0.9,
+      padding: const EdgeInsets.only(top: 15, right: 0.99),
+      decoration: ShapeDecoration(
+        color: Colors.white,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10),
+        ),
+      ),
+      child: Column(
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(
+                children: [
+                  Text(
+                    title,
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 14,
+                      fontFamily: 'Inter',
+                      fontWeight: FontWeight.w700,
+                      height: 0,
+                    ),
                   ),
-                )
-              ],
+                ],
+              ),
+              Row(
+                children: [
+                  Text(
+                    '더 보기',
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 12,
+                      fontFamily: 'Inter',
+                      fontWeight: FontWeight.w400,
+                      height: 0,
+                    ),
+                  ),
+                  IconButton(
+                      onPressed: () {
+                        if (page == 'notice') {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                                builder: (context) => NoticeScreenDetail()),
+                          );
+                        } else {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                                builder: (context) => NoticeScreenSimilar()),
+                          );
+                        }
+                      },
+                      icon: Icon(Icons.arrow_right)),
+                ],
+              ),
+            ],
+          ),
+          Container(
+            height: 300,
+            child: ListView.builder(
+              itemCount: noticeData.length,
+              itemBuilder: (context, index) {
+                final notice = noticeData[index.toString()];
+                if (notice != null) {
+                  return ListTile(
+                    title: Text(notice['title'] ?? ''),
+                    subtitle: Text(notice['category'] ?? ''),
+                    onTap: () {
+                      print('Clicked on ${notice['title']}');
+                      // Navigator.push(
+                      //   context,
+                      //   MaterialPageRoute(
+                      //     builder: (context) => WebViewScreen(url: notice['link'] ?? ''),
+                      //   ),
+                      // );
+                    },
+                  );
+                } else {
+                  return SizedBox(); // 에러를 피하기 위해 빈 위젯을 반환합니다.
+                }
+              },
             ),
-          )),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/view/notice_screen_detail.dart
+++ b/lib/view/notice_screen_detail.dart
@@ -1,0 +1,390 @@
+import 'package:flutter/material.dart';
+
+import '../component/announce_tag.dart';
+
+class NoticeScreenDetail extends StatefulWidget {
+  const NoticeScreenDetail({super.key});
+
+  @override
+  State<NoticeScreenDetail> createState() => _NoticeScreenDetailState();
+}
+
+class _NoticeScreenDetailState extends State<NoticeScreenDetail> {
+  List<String> announce_topic_name = ['인하대학교', 'SW중심대학', '컴퓨터공학'];
+  int min_list_num = 1;
+  int current_list_num = 0;
+  int notice_screen_topic_num = 0;
+  TextEditingController? _controller = TextEditingController(text: '');
+  bool _isExpanded = false;
+
+  final Map<String, Map<String, Map<String, String>>> _DateNoticeData = {
+    '2024.01.28': {
+      '0': {
+        'title': '[현장실습] 2024-1학기 (주)세정 표준 현장실습학기제 참여 학생 모집(의상디자인, 상품MD)',
+        'category': '인턴십 💼',
+        'link': "http://www.naver.com"
+      },
+      '1': {
+        'title': '[현장실습] 2024-1학기 (주)세정 표준 현장실습학기제 참여 학생 모집(의상디자인, 상품MD)',
+        'category': '인턴십 💼',
+        'link': "http://www.naver.com",
+      },
+      '2': {
+        'title': '[현장실습] 2024-1학기 (주)세정 표준 현장실습학기제 참여 학생 모집(의상디자인, 상품MD)',
+        'category': '인턴십 💼',
+        'link': "http://www.naver.com",
+      },
+    },
+    '2024.01.29': {
+      '0': {
+        'title': '[현장실습] 2024-1학기 (주)세정 표준 현장실습학기제 참여 학생 모집(의상디자인, 상품MD)',
+        'category': '인턴십 💼',
+        'link': "http://www.naver.com"
+      },
+      '1': {
+        'title': '[현장실습] 2024-1학기 (주)세정 표준 현장실습학기제 참여 학생 모집(의상디자인, 상품MD)',
+        'category': '인턴십 💼',
+        'link': "http://www.naver.com",
+      },
+      '2': {
+        'title': '[현장실습] 2024-1학기 (주)세정 표준 현장실습학기제 참여 학생 모집(의상디자인, 상품MD)',
+        'category': '인턴십 💼',
+        'link': "http://www.naver.com",
+      },
+    },
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: [
+          Stack(children: [
+            Container(
+              height: 30,
+              child: Center(
+                child: ListView.separated(
+                  shrinkWrap: true,
+                  separatorBuilder: (context, index) {
+                    return Text(
+                      '|',
+                      style: TextStyle(fontSize: 14),
+                    );
+                  },
+                  itemCount: announce_topic_name.length,
+                  scrollDirection: Axis.horizontal,
+                  itemBuilder: (context, index) {
+                    return GestureDetector(
+                      onTap: () {
+                        setState(() {
+                          notice_screen_topic_num = index;
+                        });
+                        print(index);
+                      },
+                      child: Padding(
+                        padding: EdgeInsets.fromLTRB(5, 0, 5, 0),
+                        child: Text(
+                          announce_topic_name[index],
+                          style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: (index == notice_screen_topic_num)
+                                  ? FontWeight.bold
+                                  : FontWeight.normal),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+            Align(
+              alignment: Alignment.centerRight,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(0, 2.5, 10, 0),
+                child: GestureDetector(
+                    child: Text('추가하기',
+                        style: TextStyle(
+                            color: Colors.black38,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 11)),
+                    onTap: () {}),
+              ),
+            )
+          ]),
+
+          //검색창
+          Container(
+            padding: EdgeInsets.fromLTRB(8, 0, 8, 0),
+            decoration: BoxDecoration(
+              color: Colors.grey.shade200,
+              borderRadius: BorderRadius.circular(20),
+            ),
+            width: MediaQuery.of(context).size.width * 0.87,
+            height: 35,
+            margin: EdgeInsets.fromLTRB(0, 0, 0, 3),
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  GestureDetector(
+                    onTap: () {
+                      setState(() {
+                        _isExpanded = !_isExpanded;
+                        if (_isExpanded) {
+                          // 확장되면서 포커스 설정
+                          FocusScope.of(context).requestFocus(FocusNode());
+                        }
+                      });
+                    },
+                    child: Icon(Icons.search, size: 19),
+                  ),
+                  if (_isExpanded)
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(5, 0, 0, 0),
+                        child: AnimatedContainer(
+                          duration: Duration(milliseconds: 300),
+                          width: _isExpanded ? null : 0,
+                          curve: Curves.easeInOut,
+                          child: TextField(
+                            controller: _controller,
+                            style: TextStyle(
+                                fontSize: 15, fontWeight: FontWeight.bold),
+                            decoration: InputDecoration(
+                              hintText: '검색어를 입력해주세요',
+                              border: InputBorder.none,
+                              hintStyle: TextStyle(color: Colors.black12),
+                            ),
+                            autofocus: true,
+                          ),
+                        ),
+                      ),
+                    ),
+                  if (_isExpanded)
+                    GestureDetector(
+                      onTap: () {
+                        setState(() {
+                          _controller?.text = '';
+                          _isExpanded = false;
+                          //포커스 해제
+                          FocusManager.instance.primaryFocus?.unfocus();
+                        });
+                      },
+                      child: Icon(Icons.cancel_outlined, size: 17),
+                    ),
+                ],
+              ),
+            ),
+            // child: Row(
+            //   crossAxisAlignment: CrossAxisAlignment.center,
+            //   children: [
+            //     Icon(Icons.search, size: 19),
+            //     Expanded(
+            //       child: Padding(
+            //         padding: const EdgeInsets.fromLTRB(5, 0, 0, 0),
+            //         child: TextField(
+            //           controller: _controller,
+            //           style:
+            //               TextStyle(fontSize: 15, fontWeight: FontWeight.bold),
+            //           decoration: InputDecoration(
+            //               hintText: '검색어를 입력해주세요',
+            //               border: InputBorder.none,
+            //               hintStyle: TextStyle(color: Colors.black12)),
+            //         ),
+            //       ),
+            //     ),
+
+            //     GestureDetector(
+            //         onTap: () {
+            //           setState(() {
+            //             print(1);
+            //             _controller?.text = '';
+            //             //포커스 해제
+            //             FocusManager.instance.primaryFocus?.unfocus();
+            //           });
+            //         },
+            //         child: Icon(Icons.cancel_outlined, size: 17)),
+            //   ],
+            // ),
+          ),
+
+          // 날짜별 공지사항
+          Container(
+            height: 37,
+            width: 400,
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(23, 8, 0, 4),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  //index에 따라 api에서 가져온 값 넣어주면 됨.
+                  Expanded(
+                    child: ListView.builder(
+                      scrollDirection: Axis.horizontal,
+                      itemCount: 5,
+                      itemBuilder: (context, index) {
+                        return announce_tag_widget(index);
+                      },
+                    ),
+                  )
+                ],
+              ),
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.fromLTRB(20, 0, 20, 0),
+            child: Divider(thickness: 1, color: Colors.grey),
+          ),
+          DatenoticeView(
+            dateNoticeData: _DateNoticeData,
+          )
+        ],
+      ),
+    );
+  }
+}
+
+class DatenoticeView extends StatelessWidget {
+  final Map<String, Map<String, Map<String, String>>> dateNoticeData;
+
+  const DatenoticeView({
+    Key? key,
+    required this.dateNoticeData,
+  }) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.only(bottom: 10),
+      width: MediaQuery.of(context).size.width * 0.9,
+      padding: const EdgeInsets.only(top: 15, right: 0.99),
+      decoration: ShapeDecoration(
+        color: Colors.white,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10),
+        ),
+      ),
+      child: Column(
+        children: [
+          // Row(
+          //   mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          //   children: [
+          //     Row(
+          //       children: [
+          //         Text(
+          //           title,
+          //           style: TextStyle(
+          //             color: Colors.black,
+          //             fontSize: 14,
+          //             fontFamily: 'Inter',
+          //             fontWeight: FontWeight.w700,
+          //             height: 0,
+          //           ),
+          //         ),
+          //       ],
+          //     ),
+          //     Row(
+          //       children: [
+          //         Text(
+          //           '더 보기',
+          //           style: TextStyle(
+          //             color: Colors.black,
+          //             fontSize: 12,
+          //             fontFamily: 'Inter',
+          //             fontWeight: FontWeight.w400,
+          //             height: 0,
+          //           ),
+          //         ),
+          //         IconButton(
+          //             onPressed: () {
+          //               Navigator.push(
+          //                 context,
+          //                 MaterialPageRoute(
+          //                     builder: (context) => NoticeScreenDetail()),
+          //               );
+          //             },
+          //             icon: Icon(Icons.arrow_right)),
+          //       ],
+          //     ),
+          //   ],
+          // ),
+          Container(
+            height: 600,
+            color: Colors.white,
+            child: ListView.builder(
+              itemCount: dateNoticeData.length,
+              itemBuilder: (context, index) {
+                final dateKey = dateNoticeData.keys.elementAt(index);
+                final noticeList = dateNoticeData[dateKey] ?? {}; // null 체크 추가
+                return Card(
+                  child: Container(
+                    color: Colors.white,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.all(8.0),
+                          child: Text(
+                            dateKey,
+                            style: TextStyle(
+                              fontSize: 20,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                        ListView.builder(
+                          shrinkWrap: true,
+                          physics: NeverScrollableScrollPhysics(),
+                          itemCount: noticeList?.length ?? 0, // null 체크 추가
+                          itemBuilder: (context, index) {
+                            final noticeKey = noticeList.keys.elementAt(index);
+                            final noticeData = noticeList[noticeKey];
+                            return ListTile(
+                              tileColor: Colors.white,
+                              title: Text(noticeData?['title'] ?? ''),
+                              subtitle: Text(noticeData?['category'] ?? ''),
+                              onTap: () {
+                                // Handle tap event
+                              },
+                            );
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          )
+          // Container(
+          //   height: 300,
+          //   child: ListView.builder(
+          //     itemCount: noticeData.length,
+          //     itemBuilder: (context, index) {
+          //       final notice = noticeData[index.toString()];
+          //       if (notice != null) {
+          //         return ListTile(
+          //           title: Text(notice['title'] ?? ''),
+          //           subtitle: Text(notice['category'] ?? ''),
+          //           onTap: () {
+          //             print('Clicked on ${notice['title']}');
+          //             // Navigator.push(
+          //             //   context,
+          //             //   MaterialPageRoute(
+          //             //     builder: (context) => WebViewScreen(url: notice['link'] ?? ''),
+          //             //   ),
+          //             // );
+          //           },
+          //         );
+          //       } else {
+          //         return SizedBox(); // 에러를 피하기 위해 빈 위젯을 반환합니다.
+          //       }
+          //     },
+          //   ),
+          // ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/notice_screen_similar.dart
+++ b/lib/view/notice_screen_similar.dart
@@ -1,0 +1,284 @@
+import 'package:flutter/material.dart';
+import 'package:myapp/view/notice_screen_detail.dart';
+
+import '../component/announce_tag.dart';
+
+class NoticeScreenSimilar extends StatefulWidget {
+  const NoticeScreenSimilar({super.key});
+
+  @override
+  State<NoticeScreenSimilar> createState() => _NoticeScreenSimilarState();
+}
+
+class _NoticeScreenSimilarState extends State<NoticeScreenSimilar> {
+  List<String> announce_topic_name = ['인하대학교', 'SW중심대학', '컴퓨터공학'];
+  int min_list_num = 1;
+  int current_list_num = 0;
+  int notice_screen_topic_num = 0;
+  TextEditingController? _controller = TextEditingController(text: '');
+  bool _isExpanded = false;
+
+  final Map<String, Map<String, String>> _SimilarNoticeData = {
+    '0': {
+      'date': '2024.02.28',
+      'major': '컴퓨터공학과',
+      'title': '[프런티어학부대학] 연구원 채용 공고',
+      'category': '채용 👔',
+      'link': "http://www.naver.com",
+    },
+    '1': {
+      'date': '2024.02.28',
+      'major': '컴퓨터공학과',
+      'title': '[프런티어학부대학] 연구원 채용 공고',
+      'category': '채용 👔',
+      'link': "http://www.naver.com",
+    },
+    '2': {
+      'date': '2024.02.28',
+      'major': '컴퓨터공학과',
+      'title': '[프런티어학부대학] 연구원 채용 공고',
+      'category': '채용 👔',
+      'link': "http://www.naver.com",
+    },
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("나와 비슷한 사용자가 본 공지사항"),
+      ),
+      body: Column(
+        children: [
+          // 날짜별 공지사항
+          Container(
+            height: 37,
+            width: 400,
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(23, 8, 0, 4),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  //index에 따라 api에서 가져온 값 넣어주면 됨.
+                  Expanded(
+                    child: ListView.builder(
+                      scrollDirection: Axis.horizontal,
+                      itemCount: 5,
+                      itemBuilder: (context, index) {
+                        return announce_tag_widget(index);
+                      },
+                    ),
+                  )
+                ],
+              ),
+            ),
+          ),
+          Padding(
+            padding: EdgeInsets.fromLTRB(20, 0, 20, 0),
+            child: Divider(thickness: 1, color: Colors.grey),
+          ),
+          noticeView(
+            noticeData: _SimilarNoticeData,
+          )
+        ],
+      ),
+    );
+  }
+}
+
+class DatenoticeView extends StatelessWidget {
+  final Map<String, Map<String, Map<String, String>>> dateNoticeData;
+
+  const DatenoticeView({
+    Key? key,
+    required this.dateNoticeData,
+  }) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.only(bottom: 10),
+      width: MediaQuery.of(context).size.width * 0.9,
+      padding: const EdgeInsets.only(top: 15, right: 0.99),
+      decoration: ShapeDecoration(
+        color: Colors.white,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10),
+        ),
+      ),
+      child: Column(
+        children: [
+          // Row(
+          //   mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          //   children: [
+          //     Row(
+          //       children: [
+          //         Text(
+          //           title,
+          //           style: TextStyle(
+          //             color: Colors.black,
+          //             fontSize: 14,
+          //             fontFamily: 'Inter',
+          //             fontWeight: FontWeight.w700,
+          //             height: 0,
+          //           ),
+          //         ),
+          //       ],
+          //     ),
+          //     Row(
+          //       children: [
+          //         Text(
+          //           '더 보기',
+          //           style: TextStyle(
+          //             color: Colors.black,
+          //             fontSize: 12,
+          //             fontFamily: 'Inter',
+          //             fontWeight: FontWeight.w400,
+          //             height: 0,
+          //           ),
+          //         ),
+          //         IconButton(
+          //             onPressed: () {
+          //               Navigator.push(
+          //                 context,
+          //                 MaterialPageRoute(
+          //                     builder: (context) => NoticeScreenSimilar()),
+          //               );
+          //             },
+          //             icon: Icon(Icons.arrow_right)),
+          //       ],
+          //     ),
+          //   ],
+          // ),
+          Container(
+            height: 600,
+            color: Colors.white,
+            child: ListView.builder(
+              itemCount: dateNoticeData.length,
+              itemBuilder: (context, index) {
+                final dateKey = dateNoticeData.keys.elementAt(index);
+                final noticeList = dateNoticeData[dateKey] ?? {}; // null 체크 추가
+                return Card(
+                  child: Container(
+                    color: Colors.white,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.all(8.0),
+                          child: Text(
+                            dateKey,
+                            style: TextStyle(
+                              fontSize: 20,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                        ListView.builder(
+                          shrinkWrap: true,
+                          physics: NeverScrollableScrollPhysics(),
+                          itemCount: noticeList?.length ?? 0, // null 체크 추가
+                          itemBuilder: (context, index) {
+                            final noticeKey = noticeList.keys.elementAt(index);
+                            final noticeData = noticeList[noticeKey];
+                            return ListTile(
+                              tileColor: Colors.white,
+                              title: Text(noticeData?['title'] ?? ''),
+                              subtitle: Text(noticeData?['category'] ?? ''),
+                              onTap: () {
+                                // Handle tap event
+                              },
+                            );
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          )
+          // Container(
+          //   height: 300,
+          //   child: ListView.builder(
+          //     itemCount: noticeData.length,
+          //     itemBuilder: (context, index) {
+          //       final notice = noticeData[index.toString()];
+          //       if (notice != null) {
+          //         return ListTile(
+          //           title: Text(notice['title'] ?? ''),
+          //           subtitle: Text(notice['category'] ?? ''),
+          //           onTap: () {
+          //             print('Clicked on ${notice['title']}');
+          //             // Navigator.push(
+          //             //   context,
+          //             //   MaterialPageRoute(
+          //             //     builder: (context) => WebViewScreen(url: notice['link'] ?? ''),
+          //             //   ),
+          //             // );
+          //           },
+          //         );
+          //       } else {
+          //         return SizedBox(); // 에러를 피하기 위해 빈 위젯을 반환합니다.
+          //       }
+          //     },
+          //   ),
+          // ),
+        ],
+      ),
+    );
+  }
+}
+
+class noticeView extends StatelessWidget {
+  final Map<String, Map<String, String>> noticeData;
+
+  const noticeView({
+    Key? key,
+    required this.noticeData,
+  }) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.only(bottom: 10),
+      width: MediaQuery.of(context).size.width * 0.9,
+      padding: const EdgeInsets.only(top: 15, right: 0.99),
+      decoration: ShapeDecoration(
+        color: Colors.white,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10),
+        ),
+      ),
+      child: Column(
+        children: [
+          Container(
+            height: 300,
+            child: ListView.builder(
+              itemCount: noticeData.length,
+              itemBuilder: (context, index) {
+                final notice = noticeData[index.toString()];
+                if (notice != null) {
+                  return ListTile(
+                    title: Text(notice['title'] ?? ''),
+                    subtitle: Text(notice['category'] ?? ''),
+                    onTap: () {
+                      print('Clicked on ${notice['title']}');
+                      // Navigator.push(
+                      //   context,
+                      //   MaterialPageRoute(
+                      //     builder: (context) => WebViewScreen(url: notice['link'] ?? ''),
+                      //   ),
+                      // );
+                    },
+                  );
+                } else {
+                  return SizedBox(); // 에러를 피하기 위해 빈 위젯을 반환합니다.
+                }
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
이전 반영사항 (저번에 작성하지 않아 짧게 요약합니다)
1. 강의평 작성하기 (evaluateScreenWrite)
2. 강의평 상세보기 (evaluateScreenDetail) 
각 구현했습니다. 
===

1. 각 로고 이미지 변경했습니다.
3. 포인트 항목 없앴습니다.
4. 공지사항 메인 화면 바꿨습니다. 
    -1. 즐겨찾기 항목 (noticeScreenDetail)
    -2. 비슷한 사용자가 본 공지사항 항목 (noticeScreenSimilar)
각 항목마다 더보기 항목 구현했습니다. 

<img width="375" alt="image" src="https://github.com/INfoU-INHA-for-U/INfoU/assets/72590336/2f84a3dd-50ba-456c-b746-1b94bffba4a3">

5. 즐겨찾기 페이지 더보기의 경우, 검색 창 부분이 미완입니다. 민혜님께서 말씀해주신대로 구현하려 했으나, 정민님께서 위젯 개념으로 구현한 부분이라 손을 대기가 애매했습니다. 회의 시 추가 설명 드리겠습니다.
