### PR TITLE
홈 페이지 수정 & 마이 페이지 구현, 세부구현 

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,7 +18,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: register_screen_nickname(),
+      home: mypage_screen(),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,7 +18,7 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: mypage_screen(),
+      home: splash_screen(),
     );
   }
 }

--- a/lib/view/homescreen.dart
+++ b/lib/view/homescreen.dart
@@ -1,5 +1,7 @@
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/material.dart';
+import 'package:myapp/view/notice_screen.dart';
+import 'package:myapp/widget/home_notice_view.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 
 class home_screen extends StatefulWidget {
@@ -11,13 +13,147 @@ class home_screen extends StatefulWidget {
 
 class _home_screenState extends State<home_screen> {
   //공지사항 위젯
-  List<Widget> announce_list = [
-    Text('공지사항 1번'),
-    Text('공지사항 2번'),
-    Text('공지사항 3번'),
-    Text('공지사항 4번'),
-    Text('공지사항 5번'),
-  ];
+  final Map<String, Map<String, String>> announce_list = {
+    '0': {
+      'date': '2024.02.28',
+      'major': '컴퓨터공학과',
+      'title': '[프런티어학부대학] 연구원 채용 공고',
+      'category': '채용 👔',
+      'link': "http://www.naver.com",
+    },
+    '1': {
+      'date': '2024.02.28',
+      'major': '컴퓨터공학과',
+      'title': '[프런티어학부대학] 연구원 채용 공고',
+      'category': '채용 👔',
+      'link': "http://www.naver.com",
+    },
+    '2': {
+      'date': '2024.02.28',
+      'major': '컴퓨터공학과',
+      'title': '[프런티어학부대학] 연구원 채용 공고',
+      'category': '채용 👔',
+      'link': "http://www.naver.com",
+    },
+  };
+
+  Map _recent_evaluate_data = {
+    '0': {
+      'class': '파이썬 프로그래밍',
+      'professor': '서영덕',
+      'star_rate': 4,
+      'evaluate1': '정말 좋아요',
+      'evaluate2': '적당해요',
+      'recommend_rate': 4.7
+    },
+    '1': {
+      'class': '클라우드 컴퓨팅',
+      'professor': '권구인',
+      'star_rate': 4,
+      'evaluate1': '정말 좋아요',
+      'evaluate2': '어려워요',
+      'recommend_rate': 4.9
+    },
+    '2': {
+      'class': '클라우드 컴퓨팅',
+      'professor': '권구인',
+      'star_rate': 4,
+      'evaluate1': '정말 좋아요',
+      'evaluate2': '어려워요',
+      'recommend_rate': 4.9
+    },
+  };
+
+  //최근 강의평 위젯
+  Widget _recent_evaluate_widget(int index) {
+    Map _current_evaluate_data = _recent_evaluate_data[index.toString()];
+    return Padding(
+      padding: EdgeInsets.fromLTRB(13, 10, 20, 10),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(3, 0, 0, 0),
+                child: Text(
+                    _current_evaluate_data['class'] +
+                        ' [' +
+                        _current_evaluate_data['professor'] +
+                        ']',
+                    style: TextStyle(fontSize: 15)),
+              ),
+              Padding(
+                padding: EdgeInsets.fromLTRB(0, 5, 0, 5),
+                child: Container(
+                  width: 200,
+                  height: 30,
+                  child: ListView.builder(
+                    scrollDirection: Axis.horizontal,
+                    itemCount: 5,
+                    itemBuilder: (context, index) {
+                      //별 표시해주는겁니다. api식으로 바로 사용할수있게 코딩해놨습니다.
+                      if (index < _current_evaluate_data['star_rate'])
+                        return const Icon(Icons.star, color: Colors.amber);
+                      else
+                        return const Icon(Icons.star, color: Colors.grey);
+                    },
+                  ),
+                ),
+              ),
+              Row(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(0, 0, 5, 0),
+                    child: Container(
+                      decoration: BoxDecoration(
+                          color: Colors.white,
+                          borderRadius: BorderRadius.circular(5)),
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(7, 0, 7, 0),
+                        child: Row(
+                          children: [
+                            Text(_current_evaluate_data['evaluate1'] + ' ',
+                                style: TextStyle(fontSize: 14)),
+                            //해당 이미지가 없어서 일단 아이콘으로 대체했습니다.
+                            Icon(Icons.thumb_up_alt_outlined, size: 13)
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(5, 0, 5, 0),
+                    child: Container(
+                        decoration: BoxDecoration(
+                            color: Colors.white,
+                            borderRadius: BorderRadius.circular(5)),
+                        child: Padding(
+                          padding: const EdgeInsets.fromLTRB(7, 0, 7, 0),
+                          child: Row(
+                            children: [
+                              Text(_current_evaluate_data['evaluate2'] + ' ',
+                                  style: TextStyle(fontSize: 14)),
+                              //해당 이미지가 없어서 일단 아이콘으로 대체했습니다.
+                              Icon(Icons.thumb_down_alt_outlined, size: 13)
+                            ],
+                          ),
+                        )),
+                  )
+                ],
+              )
+            ],
+          ),
+          Column(mainAxisAlignment: MainAxisAlignment.center, children: [
+            Text('추천도'),
+            Text(_current_evaluate_data['recommend_rate'].toString(),
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 25))
+          ])
+        ],
+      ),
+    );
+  }
 
   var activeBannerIndex = 0;
 
@@ -94,75 +230,78 @@ class _home_screenState extends State<home_screen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+        appBar: AppBar(
+          title: Text("InfoU"),
+        ),
         body: Container(
-      child: Column(
-        children: [
-          Container(
-            height: 180,
-            child: sliderBannerWidget(),
-          ),
-          Container(
-            height: MediaQuery.of(context).size.height * 0.2,
+          child: SingleChildScrollView(
             child: Column(
               children: [
-                Padding(
-                  padding: EdgeInsets.fromLTRB(20, 10, 20, 0),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                Container(
+                  height: 180,
+                  child: sliderBannerWidget(),
+                ),
+                Container(
+                  child: Column(
                     children: [
-                      Text(
-                        '오늘의 공지사항',
-                        style: TextStyle(
-                            fontWeight: FontWeight.bold, fontSize: 18),
+                      Padding(
+                        padding: EdgeInsets.fromLTRB(20, 10, 20, 0),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              '전체 공지사항',
+                              style: TextStyle(
+                                  fontWeight: FontWeight.bold, fontSize: 18),
+                            ),
+                            TextButton(onPressed: () {}, child: Text('더 보기 > '))
+                          ],
+                        ),
                       ),
-                      TextButton(onPressed: () {}, child: Text('더 보기 > '))
+                      homeNoticeView(noticeData: announce_list),
                     ],
                   ),
                 ),
-                Expanded(
-                    child: ListView.builder(
-                        scrollDirection: Axis.vertical,
-                        itemCount: announce_list.length,
+                Divider(
+                  color: Colors.black,
+                ),
+                Column(
+                  children: [
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(20, 0, 20, 0),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text('최근 강의평',
+                              style: TextStyle(
+                                  fontSize: 20, fontWeight: FontWeight.bold)),
+                          TextButton(onPressed: () {}, child: Text('더보기 > '))
+                        ],
+                      ),
+                    ),
+                    Container(
+                      height: 260,
+                      child: ListView.builder(
+                        physics: NeverScrollableScrollPhysics(),
                         itemBuilder: (context, index) {
                           return Padding(
-                              padding: EdgeInsets.all(5),
-                              child: announce_list[index]);
-                        })),
+                              padding: EdgeInsets.fromLTRB(20, 10, 20, 10),
+                              child: Container(
+                                decoration: BoxDecoration(
+                                    color: Colors.grey.shade200,
+                                    borderRadius: BorderRadius.circular(15)),
+                                height: 110,
+                                child: _recent_evaluate_widget(index),
+                              ));
+                        },
+                        itemCount: _recent_evaluate_data.length - 1,
+                      ),
+                    ),
+                  ],
+                )
               ],
             ),
           ),
-          Divider(
-            color: Colors.black,
-          ),
-          Expanded(
-            child: Column(
-              children: [
-                Padding(
-                  padding: EdgeInsets.fromLTRB(20, 0, 20, 0),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text('최근 강의평',
-                          style: TextStyle(
-                              fontSize: 20, fontWeight: FontWeight.bold)),
-                      TextButton(onPressed: () {}, child: Text('더보기 > '))
-                    ],
-                  ),
-                ),
-                Expanded(
-                    child: ListView.builder(
-                  itemCount: announce_list.length,
-                  itemBuilder: (context, index) {
-                    return Padding(
-                        padding: EdgeInsets.all(5),
-                        child: announce_list[index]);
-                  },
-                ))
-              ],
-            ),
-          )
-        ],
-      ),
-    ));
+        ));
   }
 }

--- a/lib/view/mypagescreen.dart
+++ b/lib/view/mypagescreen.dart
@@ -15,269 +15,162 @@ class _mypage_screenState extends State<mypage_screen> {
     double baseWidth = 360;
     double fem = MediaQuery.of(context).size.width / baseWidth;
     double ffem = fem * 0.97;
-    return Container(
-      width: double.infinity,
-      child: Container(
-        // mypagescreenpgD (2:549)
-        padding: EdgeInsets.fromLTRB(0 * fem, 1 * fem, 0 * fem, 0 * fem),
-        width: double.infinity,
-        decoration: BoxDecoration(
-          color: Color(0xffffffff),
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          "마이페이지",
+          style: TextStyle(
+            color: Colors.black,
+            fontSize: 20,
+            fontFamily: 'Roboto',
+            fontWeight: FontWeight.w800,
+            height: 0,
+            letterSpacing: 0.02,
+          ),
         ),
-        child: SingleChildScrollView(
-          child: Column(
+        actions: [
+          IconButton(
+            icon: Icon(Icons.settings), // 톱니바퀴 모양의 아이콘
+            onPressed: () {
+              // 아이콘 버튼을 눌렀을 때의 동작을 정의하세요
+              // 예: 설정 화면으로 이동
+            },
+          ),
+        ],
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 1번, 이름과 이메일
+          Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Container(
-                // autogroupsnxmimb (6aNjLj6VaU6HcC6FuWsnxm)
-                margin:
-                    EdgeInsets.fromLTRB(1 * fem, 0 * fem, 0 * fem, 15 * fem),
-                padding:
-                    EdgeInsets.fromLTRB(17 * fem, 16 * fem, 17 * fem, 15 * fem),
-                width: double.infinity,
-                decoration: BoxDecoration(
-                  color: Color(0xffffffff),
-                ),
-                child: Text(
-                  '마이페이지',
-                  style: SafeGoogleFont(
-                    'Inter',
-                    fontSize: 17 * ffem,
-                    fontWeight: FontWeight.w700,
-                    height: 1.2125 * ffem / fem,
-                    color: Color(0xff000000),
-                  ),
+              Text(
+                '[닉네임] 님',
+                style: TextStyle(
+                  color: Colors.black,
+                  fontSize: 15,
+                  fontFamily: 'Inter',
+                  fontWeight: FontWeight.w700,
+                  height: 0,
                 ),
               ),
-              Container(
-                // autogroupjxvma37 (6aNjSJmXbDK2MrRckyJXvM)
-                margin:
-                    EdgeInsets.fromLTRB(0 * fem, 0 * fem, 0 * fem, 24 * fem),
-                padding: EdgeInsets.fromLTRB(
-                    22.58 * fem, 14.58 * fem, 230 * fem, 13.58 * fem),
-                width: double.infinity,
-                decoration: BoxDecoration(
-                  color: Color(0xfff7f7f7),
+              Text(
+                'push@inha.edu',
+                style: TextStyle(
+                  color: Color(0xFFBBBBBB),
+                  fontSize: 9,
+                  fontFamily: 'Inter',
+                  fontWeight: FontWeight.w700,
+                  height: 0,
                 ),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Container(
-                      // healthiconsuiuserprofilesH7 (2:578)
-                      margin: EdgeInsets.fromLTRB(
-                          0 * fem, 0 * fem, 7.58 * fem, 0 * fem),
-                      width: 35.83 * fem,
-                      height: 35.83 * fem,
-                      child: Image.asset(
-                        'assets/page-1/images/healthicons-ui-user-profile.png',
-                        width: 35.83 * fem,
-                        height: 35.83 * fem,
-                      ),
-                    ),
-                    Container(
-                      // autogroupyrxdaBX (6aNjZ45HaP9KRHzYY3Yrxd)
-                      constraints: BoxConstraints(
-                        maxWidth: 200.0, // 최대 가로 사이즈를 설정
-                      ),
-                      margin: EdgeInsets.fromLTRB(
-                          0 * fem, 0 * fem, 0 * fem, 1 * fem),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Container(
-                            // W5B (2:552)
-                            margin: EdgeInsets.fromLTRB(
-                                0 * fem, 0 * fem, 0 * fem, 6 * fem),
-
-                            child: Text(
-                              '하성민',
-                              style: SafeGoogleFont(
-                                'Inter',
-                                fontSize: 12 * ffem,
-                                fontWeight: FontWeight.w700,
-                                height: 1.2125 * ffem / fem,
-                                color: Color(0xff000000),
-                              ),
-                            ),
-                          ),
-                          Text(
-                            // 1nd (2:551)
-                            '내 정보',
-                            style: SafeGoogleFont(
-                              'Inter',
-                              fontSize: 10 * ffem,
-                              fontWeight: FontWeight.w400,
-                              height: 1.2125 * ffem / fem,
-                              color: Color(0xff3a4ca8),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              Container(
-                // group40Z3T (2:566)
-                padding: EdgeInsets.fromLTRB(
-                    18.1 * fem, 22 * fem, 18.1 * fem, 23 * fem),
-                width: 361 * fem,
-                decoration: BoxDecoration(
-                  color: Color(0xfff7f7f7),
-                ),
-                child: menuWidget('포인트', fem, ffem),
-              ),
-              Container(
-                // group40Z3T (2:566)
-                padding: EdgeInsets.fromLTRB(
-                    18.1 * fem, 22 * fem, 18.1 * fem, 23 * fem),
-                width: 361 * fem,
-                decoration: BoxDecoration(
-                  color: Color(0xfff7f7f7),
-                ),
-                child: menuWidget('이용 안내', fem, ffem),
               ),
             ],
           ),
-        ),
+
+          // 2번, 강의평가
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '강의평가',
+                style: TextStyle(
+                  color: Colors.black,
+                  fontSize: 12,
+                  fontFamily: 'Inter',
+                  fontWeight: FontWeight.w700,
+                  height: 0,
+                ),
+              ),
+              Row(
+                children: [
+                  MyPageCard(title: '보유 포인트', count: '300P'),
+                  MyPageCard(title: '작성 리뷰', count: '2')
+                ],
+              ),
+            ],
+          ),
+
+          // 3번, 공지사항
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '공지사항',
+                style: TextStyle(
+                  color: Colors.black,
+                  fontSize: 12,
+                  fontFamily: 'Inter',
+                  fontWeight: FontWeight.w700,
+                  height: 0,
+                ),
+              ),
+              Row(
+                children: [
+                  MyPageCard(title: '즐겨찾는 학과', count: '2'),
+                ],
+              ),
+            ],
+          ),
+        ],
       ),
     );
   }
+}
 
-  Column menuWidget(String str, double fem, double ffem) {
-    // str: 메뉴위젯 이름
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Container(
-          // TuX (2:568)
-          margin: EdgeInsets.fromLTRB(0 * fem, 0 * fem, 0 * fem, 22 * fem),
-          child: Text(
-            str,
-            style: SafeGoogleFont(
-              'Inter',
-              fontSize: 14 * ffem,
+class MyPageCard extends StatelessWidget {
+  final String title;
+  final String count;
+
+  const MyPageCard({
+    Key? key,
+    required this.title,
+    required this.count,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 154,
+      height: 111,
+      padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 20),
+      decoration: ShapeDecoration(
+        color: Color(0xFFF1F8FF),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(15),
+        ),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Text(
+            title,
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: Colors.black,
+              fontSize: 12,
+              fontFamily: 'Inter',
               fontWeight: FontWeight.w700,
-              height: 1.2125 * ffem / fem,
-              color: Color(0xff000000),
+              height: 0,
             ),
           ),
-        ),
-        Container(
-          // group39zPf (2:569)
-          width: double.infinity,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              Container(
-                // autogroupefkyYRB (6aNmp59JxCt7ihvFgwEfky)
-                margin:
-                    EdgeInsets.fromLTRB(0 * fem, 0 * fem, 0.81 * fem, 0 * fem),
-                width: double.infinity,
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    menuWidgetElement('📚 시간표 사진 등록하기', fem, ffem),
-                    Container(
-                      // chevronrightNv1 (2:574)
-                      width: 17.09 * fem,
-                      height: 12 * fem,
-                      child: Image.asset(
-                        'assets/page-1/images/chevron-right-NEh.png',
-                        fit: BoxFit.contain,
-                      ),
-                    ),
-                  ],
-                ),
+          SizedBox(
+            width: 94,
+            child: Text(
+              count,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: Colors.black,
+                fontSize: 12,
+                fontFamily: 'Inter',
+                fontWeight: FontWeight.w400,
+                height: 0,
               ),
-              SizedBox(
-                height: 23 * fem,
-              ),
-              Container(
-                // autogroup71zwVDw (6aNmuZz9gVVAsxJncr71Zw)
-                width: double.infinity,
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    menuWidgetElement('📚 시간표 사진 등록하기', fem, ffem),
-                    Container(
-                      // chevronrightxdK (2:577)
-                      width: 17.09 * fem,
-                      height: 12 * fem,
-                      child: Image.asset(
-                        'assets/page-1/images/chevron-right-mSd.png',
-                        fit: BoxFit.contain,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              SizedBox(
-                height: 23 * fem,
-              ),
-              Container(
-                // autogrouprz5fVt9 (6aNmzuAbqrrrrNofhfrZ5f)
-                width: double.infinity,
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    menuWidgetElement('📚 리뷰 남기고 포인트 등록하기', fem, ffem),
-                    Container(
-                      // chevronrightmKs (2:575)
-                      width: 17.09 * fem,
-                      height: 12 * fem,
-                      child: Image.asset(
-                        'assets/page-1/images/chevron-right.png',
-                        fit: BoxFit.fitWidth,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              SizedBox(
-                height: 23 * fem,
-              ),
-              Container(
-                // autogroupnvzuhzD (6aNn5u2GsPmpT9XF6KNVzu)
-                margin:
-                    EdgeInsets.fromLTRB(1.01 * fem, 0 * fem, 0 * fem, 0 * fem),
-                width: double.infinity,
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    menuWidgetElement('👛 이용권 구매하기', fem, ffem),
-                    Container(
-                      // chevronrightx9T (2:576)
-                      width: 17.09 * fem,
-                      height: 12 * fem,
-                      child: Image.asset(
-                        'assets/page-1/images/chevron-right-Mph.png',
-                        fit: BoxFit.fill,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
+            ),
           ),
-        ),
-      ],
-    );
-  }
-
-  Container menuWidgetElement(String str, double fem, double ffem) {
-    return Container(
-      // V5X (2:570)
-      margin: EdgeInsets.fromLTRB(0 * fem, 0 * fem, 150.9 * fem, 0 * fem),
-      child: Text(
-        str,
-        style: SafeGoogleFont(
-          'Inter',
-          fontSize: 11 * ffem,
-          fontWeight: FontWeight.w700,
-          height: 1.2125 * ffem / fem,
-          color: Color(0xff000000),
-        ),
+        ],
       ),
     );
   }

--- a/lib/view/mypagescreen.dart
+++ b/lib/view/mypagescreen.dart
@@ -3,6 +3,8 @@ import 'package:flutter/gestures.dart';
 import 'dart:ui';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:myapp/utils.dart';
+import 'package:myapp/view/mypagescreen_point.dart';
+import 'package:myapp/view/mypagescreen_setting.dart';
 
 class mypage_screen extends StatefulWidget {
   @override
@@ -32,87 +34,99 @@ class _mypage_screenState extends State<mypage_screen> {
           IconButton(
             icon: Icon(Icons.settings), // 톱니바퀴 모양의 아이콘
             onPressed: () {
-              // 아이콘 버튼을 눌렀을 때의 동작을 정의하세요
-              // 예: 설정 화면으로 이동
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => MypageScreenSetting()),
+              );
             },
           ),
         ],
       ),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // 1번, 이름과 이메일
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                '[닉네임] 님',
-                style: TextStyle(
-                  color: Colors.black,
-                  fontSize: 15,
-                  fontFamily: 'Inter',
-                  fontWeight: FontWeight.w700,
-                  height: 0,
-                ),
-              ),
-              Text(
-                'push@inha.edu',
-                style: TextStyle(
-                  color: Color(0xFFBBBBBB),
-                  fontSize: 9,
-                  fontFamily: 'Inter',
-                  fontWeight: FontWeight.w700,
-                  height: 0,
-                ),
-              ),
-            ],
-          ),
-
-          // 2번, 강의평가
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                '강의평가',
-                style: TextStyle(
-                  color: Colors.black,
-                  fontSize: 12,
-                  fontFamily: 'Inter',
-                  fontWeight: FontWeight.w700,
-                  height: 0,
-                ),
-              ),
-              Row(
+      body: Padding(
+        padding: const EdgeInsets.all(15.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 1번, 이름과 이메일
+            Container(
+              margin: EdgeInsets.fromLTRB(0, 0, 0, 15),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  MyPageCard(title: '보유 포인트', count: '300P'),
-                  MyPageCard(title: '작성 리뷰', count: '2')
+                  Text(
+                    '[닉네임] 님',
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 15,
+                      fontFamily: 'Inter',
+                      fontWeight: FontWeight.w700,
+                      height: 0,
+                    ),
+                  ),
+                  Text(
+                    'push@inha.edu',
+                    style: TextStyle(
+                      color: Color(0xFFBBBBBB),
+                      fontSize: 9,
+                      fontFamily: 'Inter',
+                      fontWeight: FontWeight.w700,
+                      height: 0,
+                    ),
+                  ),
                 ],
               ),
-            ],
-          ),
+            ),
 
-          // 3번, 공지사항
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                '공지사항',
-                style: TextStyle(
-                  color: Colors.black,
-                  fontSize: 12,
-                  fontFamily: 'Inter',
-                  fontWeight: FontWeight.w700,
-                  height: 0,
-                ),
-              ),
-              Row(
+            // 2번, 강의평가
+            Container(
+              margin: EdgeInsets.fromLTRB(0, 0, 0, 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  MyPageCard(title: '즐겨찾는 학과', count: '2'),
+                  Text(
+                    '강의평가',
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 20,
+                      fontFamily: 'Inter',
+                      fontWeight: FontWeight.w700,
+                      height: 0,
+                    ),
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      MyPageCard(title: '보유 포인트', count: '300P'),
+                      MyPageCard(title: '작성 리뷰', count: '2')
+                    ],
+                  ),
                 ],
               ),
-            ],
-          ),
-        ],
+            ),
+
+            // 3번, 공지사항
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '공지사항',
+                  style: TextStyle(
+                    color: Colors.black,
+                    fontSize: 20,
+                    fontFamily: 'Inter',
+                    fontWeight: FontWeight.w700,
+                    height: 0,
+                  ),
+                ),
+                Row(
+                  children: [
+                    MyPageCard(title: '즐겨찾는 학과', count: '2'),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -130,47 +144,57 @@ class MyPageCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: 154,
-      height: 111,
-      padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 20),
-      decoration: ShapeDecoration(
-        color: Color(0xFFF1F8FF),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(15),
-        ),
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Text(
-            title,
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              color: Colors.black,
-              fontSize: 12,
-              fontFamily: 'Inter',
-              fontWeight: FontWeight.w700,
-              height: 0,
-            ),
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => MypageScreenPoint(),
+            ));
+      },
+      child: Container(
+        width: 154 * 1.4,
+        height: 111 * 1.4,
+        padding: const EdgeInsets.symmetric(horizontal: 30, vertical: 20),
+        margin: EdgeInsets.fromLTRB(0, 0, 10, 0),
+        decoration: ShapeDecoration(
+          color: Color(0xFFF1F8FF),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(15),
           ),
-          SizedBox(
-            width: 94,
-            child: Text(
-              count,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text(
+              title,
               textAlign: TextAlign.center,
               style: TextStyle(
                 color: Colors.black,
                 fontSize: 12,
                 fontFamily: 'Inter',
-                fontWeight: FontWeight.w400,
+                fontWeight: FontWeight.w700,
                 height: 0,
               ),
             ),
-          ),
-        ],
+            SizedBox(
+              width: 94,
+              child: Text(
+                count,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: Colors.black,
+                  fontSize: 12,
+                  fontFamily: 'Inter',
+                  fontWeight: FontWeight.w400,
+                  height: 0,
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/view/mypagescreen_point.dart
+++ b/lib/view/mypagescreen_point.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
+import 'dart:ui';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:myapp/splash_screen/splash_screen.dart';
+import 'package:myapp/utils.dart';
+import 'package:myapp/view/register_screen.dart';
+
+import '../widget/list_view.dart';
+
+class MypageScreenPoint extends StatefulWidget {
+  @override
+  State<MypageScreenPoint> createState() => _MypageScreenPointState();
+}
+
+class _MypageScreenPointState extends State<MypageScreenPoint> {
+  final Map<String, Map<String, String>> pointList = {
+    '0': {
+      'point': '+ 50',
+      'totalPoint': '550',
+      'category': '강의평 작성',
+      'date': '2023.01.30',
+    },
+    '1': {
+      'point': '+ 50',
+      'totalPoint': '550',
+      'category': '강의평 작성',
+      'date': '2023.01.30',
+    },
+    '2': {
+      'point': '+ 50',
+      'totalPoint': '550',
+      'category': '강의평 작성',
+      'date': '2023.01.30',
+    },
+    '3': {
+      'point': '+ 50',
+      'totalPoint': '550',
+      'category': '강의평 작성',
+      'date': '2023.01.30',
+    },
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    double baseWidth = 360;
+    double fem = MediaQuery.of(context).size.width / baseWidth;
+    double ffem = fem * 0.97;
+    return SafeArea(
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(
+            "포인트 기록",
+            style: TextStyle(
+              color: Colors.black,
+              fontSize: 20,
+              fontFamily: 'Roboto',
+              fontWeight: FontWeight.w800,
+              height: 0,
+              letterSpacing: 0.02,
+            ),
+          ),
+        ),
+        body: Column(
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [Text('보유 포인트'), Text('550P')],
+            ),
+            Container(
+              height: 10,
+              decoration: BoxDecoration(color: Color(0xFFF7F7F7)),
+            ),
+            Expanded(
+                child: ListView.builder(
+              itemCount: pointList.length,
+              itemBuilder: (BuildContext context, int index) {
+                final item = pointList[index.toString()];
+
+                return Padding(
+                  padding: EdgeInsets.symmetric(vertical: 10, horizontal: 15),
+                  child: Container(
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Row(
+                          children: [
+                            Text(item!['point'] ?? ''),
+                            Text('p '),
+                            Text(
+                              item!['category'] ?? '',
+                            ),
+                          ],
+                        ),
+                        Column(
+                          children: [
+                            Text(
+                              (item!['totalPoint'] ?? '') + 'P',
+                            ),
+                            Text(
+                              item!['date'] ?? '',
+                            ),
+                          ],
+                        )
+                      ],
+                    ),
+                  ),
+                );
+              },
+            )),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/mypagescreen_setting.dart
+++ b/lib/view/mypagescreen_setting.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
+import 'dart:ui';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:myapp/splash_screen/splash_screen.dart';
+import 'package:myapp/utils.dart';
+import 'package:myapp/view/register_screen.dart';
+
+import '../widget/list_view.dart';
+
+class MypageScreenSetting extends StatefulWidget {
+  @override
+  State<MypageScreenSetting> createState() => _MypageScreenSettingState();
+}
+
+class _MypageScreenSettingState extends State<MypageScreenSetting> {
+  @override
+  Widget build(BuildContext context) {
+    double baseWidth = 360;
+    double fem = MediaQuery.of(context).size.width / baseWidth;
+    double ffem = fem * 0.97;
+    return SafeArea(
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(
+            "설정",
+            style: TextStyle(
+              color: Colors.black,
+              fontSize: 20,
+              fontFamily: 'Roboto',
+              fontWeight: FontWeight.w800,
+              height: 0,
+              letterSpacing: 0.02,
+            ),
+          ),
+        ),
+        body: Column(
+          children: [
+            Expanded(
+              child: LineListView(
+                itemList: const [
+                  ['사용자 정보 변경'],
+                  ['공지사항'],
+                  ['이용약관'],
+                  ['개인정보 정책'],
+                  ['오픈소스'],
+                  ['문의하기'],
+                  ['버전', '0.0.1'],
+                ],
+                onTap: [
+                  () async {
+                    // 사용자 정보 변경
+                    Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) => register_screen_nickname(),
+                        ));
+                  },
+                  () async {
+                    // 공지사항
+                  },
+                  () async {
+                    // 이용 약관
+                  },
+                  () async {
+                    // 개인정보 정책
+                  },
+                  () async {
+                    // 오픈소스
+                  },
+                  () async {
+                    // 문의하기
+                  },
+                  () async {
+                    // 버전
+                  },
+                ],
+                itemSpacing: 0.0,
+              ),
+            ),
+            Container(
+              height: 10,
+              decoration: BoxDecoration(color: Color(0xFFF7F7F7)),
+            ),
+            Expanded(
+              child: LineListView(
+                itemList: const [
+                  ['로그아웃'],
+                  ['회원 탈퇴'],
+                ],
+                onTap: [
+                  () async {
+                    // 로그아웃
+                  },
+                  () async {
+                    // 회원 탈퇴
+                  },
+                ],
+                itemSpacing: 0.0,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/notice_screen.dart
+++ b/lib/view/notice_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:myapp/view/alarm_screen.dart';
 import 'package:myapp/view/notice_screen_detail.dart';
+import 'package:myapp/view/notice_screen_favorite.dart';
 import 'package:myapp/view/notice_screen_similar.dart';
 import '../component/announce_tag.dart';
 import 'notice_screen_page.dart';
@@ -118,283 +119,298 @@ class _notice_screenState extends State<notice_screen> {
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
         theme: ThemeData(
-            scaffoldBackgroundColor: Color(0xFFF3F3F3), // 전체 배경 색상 설정
+            scaffoldBackgroundColor: Color(0xFFFFFF), // 전체 배경 색상 설정
             appBarTheme: AppBarTheme(
-              backgroundColor: Color(0xFFF3F3F3), // AppBar 배경 색상 설정
+              backgroundColor: Color(0xFFFFFF), // AppBar 배경 색상 설정
             )),
         home: Scaffold(
             appBar: AppBar(
               title: Text("공지사항"),
             ),
             resizeToAvoidBottomInset: false,
-            body: SingleChildScrollView(
-              child: Container(
-                color: Color(0xFFF3F3F3),
-                width: MediaQuery.of(context).size.width,
-                height: MediaQuery.of(context).size.height,
-                child: Column(
-                  children: [
-                    Positioned(
-                      left: 15.99,
-                      top: 99,
-                      child: Container(
-                        width: MediaQuery.of(context).size.width * 0.9,
-                        padding: const EdgeInsets.only(
-                          top: 10,
-                          left: 6,
-                          right: 14,
-                          bottom: 10,
-                        ),
-                        decoration: ShapeDecoration(
-                          color: Colors.white,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(10),
-                          ),
-                          shadows: [
-                            BoxShadow(
-                              color: Color(0x3F000000),
-                              blurRadius: 4,
-                              offset: Offset(0, 4),
-                              spreadRadius: 0,
-                            )
-                          ],
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            Text(
-                              '🔔 모든 공지사항 조회 ',
-                              style: TextStyle(
-                                color: Colors.black,
-                                fontSize: 14,
-                                fontFamily: 'Inter',
-                                fontWeight: FontWeight.w700,
-                                height: 0,
-                              ),
+            body: SafeArea(
+              child: SingleChildScrollView(
+                child: Container(
+                  color: Color(0xFFFFFF),
+                  width: MediaQuery.of(context).size.width,
+                  height: MediaQuery.of(context).size.height,
+                  child: Column(
+                    children: [
+                      Positioned(
+                        left: 15.99,
+                        top: 99,
+                        child: GestureDetector(
+                          onTap: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                  builder: (context) => NoticeScreenDetail()),
+                            );
+                            print('공지사항 조회 기능 실행');
+                          },
+                          child: Container(
+                            width: MediaQuery.of(context).size.width * 0.9,
+                            padding: const EdgeInsets.only(
+                              top: 10,
+                              left: 6,
+                              right: 14,
+                              bottom: 10,
                             ),
-                          ],
+                            decoration: ShapeDecoration(
+                              color: Colors.white,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(10),
+                                side: BorderSide(
+                                    color: Color(0xFFBBBBBB),
+                                    width: 1), // 여기서 변경
+                              ),
+                              shadows: [
+                                BoxShadow(
+                                  color: Color(0x3F000000),
+                                  blurRadius: 4,
+                                  offset: Offset(0, 4),
+                                  spreadRadius: 0,
+                                )
+                              ],
+                            ),
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: [
+                                Text(
+                                  '🔔 모든 공지사항 조회 ',
+                                  style: TextStyle(
+                                    color: Colors.black,
+                                    fontSize: 14,
+                                    fontFamily: 'Inter',
+                                    fontWeight: FontWeight.w700,
+                                    height: 0,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
                         ),
                       ),
-                    ),
-                    SizedBox(height: 10),
+                      SizedBox(height: 10),
 
-                    // 즐겨찾기 항목
-                    noticeView(
-                        title: " 📔 즐겨찾기",
-                        noticeData: _noticeData,
-                        page: 'notice'), // 공지사항
-                    noticeView(
-                        title: " 📔 비슷한 사용자가 본 공지사항",
-                        noticeData: _SimilarNoticeData,
-                        page: 'similar'), // 공지사항
+                      // 즐겨찾기 항목
+                      noticeView(
+                          title: " 📔 즐겨찾기",
+                          noticeData: _noticeData,
+                          page: 'notice'), // 공지사항
+                      noticeView(
+                          title: " 📔 비슷한 사용자가 본 공지사항",
+                          noticeData: _SimilarNoticeData,
+                          page: 'similar'), // 공지사항
 
-                    //토픽
-                    //지우셔도 됩니다.
-                    // Stack(children: [
-                    //   Container(
-                    //     height: 30,
-                    //     child: Center(
-                    //       child: ListView.separated(
-                    //         shrinkWrap: true,
-                    //         separatorBuilder: (context, index) {
-                    //           return Text(
-                    //             '|',
-                    //             style: TextStyle(fontSize: 14),
-                    //           );
-                    //         },
-                    //         itemCount: announce_topic_name.length,
-                    //         scrollDirection: Axis.horizontal,
-                    //         itemBuilder: (context, index) {
-                    //           return GestureDetector(
-                    //             onTap: () {
-                    //               setState(() {
-                    //                 notice_screen_topic_num = index;
-                    //               });
-                    //               print(index);
-                    //             },
-                    //             child: Padding(
-                    //               padding: EdgeInsets.fromLTRB(5, 0, 5, 0),
-                    //               child: Text(
-                    //                 announce_topic_name[index],
-                    //                 style: TextStyle(
-                    //                     fontSize: 14,
-                    //                     fontWeight:
-                    //                         (index == notice_screen_topic_num)
-                    //                             ? FontWeight.bold
-                    //                             : FontWeight.normal),
-                    //               ),
-                    //             ),
-                    //           );
-                    //         },
-                    //       ),
-                    //     ),
-                    //   ),
-                    //   Align(
-                    //     alignment: Alignment.centerRight,
-                    //     child: Padding(
-                    //       padding: const EdgeInsets.fromLTRB(0, 2.5, 10, 0),
-                    //       child: GestureDetector(
-                    //           child: Text('추가하기',
-                    //               style: TextStyle(
-                    //                   color: Colors.black38,
-                    //                   fontWeight: FontWeight.bold,
-                    //                   fontSize: 11)),
-                    //           onTap: () {}),
-                    //     ),
-                    //   )
-                    // ]),
-                    // //검색창
-                    // Container(
-                    //     padding: EdgeInsets.fromLTRB(8, 0, 8, 0),
-                    //     decoration: BoxDecoration(
-                    //       color: Colors.grey.shade200,
-                    //       borderRadius: BorderRadius.circular(20),
-                    //     ),
-                    //     width: MediaQuery.of(context).size.width * 0.87,
-                    //     height: 35,
-                    //     margin: EdgeInsets.fromLTRB(0, 0, 0, 3),
-                    //     child: Row(
-                    //       crossAxisAlignment: CrossAxisAlignment.center,
-                    //       children: [
-                    //         Icon(Icons.search, size: 19),
-                    //         Expanded(
-                    //           child: Padding(
-                    //             padding: const EdgeInsets.fromLTRB(5, 0, 0, 0),
-                    //             child: TextField(
-                    //               controller: _controller,
-                    //               style: TextStyle(
-                    //                   fontSize: 15,
-                    //                   fontWeight: FontWeight.bold),
-                    //               decoration: InputDecoration(
-                    //                   hintText: '검색어를 입력해주세요',
-                    //                   border: InputBorder.none,
-                    //                   hintStyle:
-                    //                       TextStyle(color: Colors.black12)),
-                    //             ),
-                    //           ),
-                    //         ),
-                    //         GestureDetector(
-                    //             onTap: () {
-                    //               setState(() {
-                    //                 print(1);
-                    //                 _controller?.text = '';
-                    //                 //포커스 해제
-                    //                 FocusManager.instance.primaryFocus
-                    //                     ?.unfocus();
-                    //               });
-                    //             },
-                    //             child: Icon(Icons.cancel_outlined, size: 17)),
-                    //       ],
-                    //     )),
-                    // Container(
-                    //   height: 37,
-                    //   width: 400,
-                    //   child: Padding(
-                    //     padding: EdgeInsets.fromLTRB(23, 8, 0, 4),
-                    //     child: Row(
-                    //       mainAxisAlignment: MainAxisAlignment.center,
-                    //       crossAxisAlignment: CrossAxisAlignment.center,
-                    //       children: [
-                    //         //index에 따라 api에서 가져온 값 넣어주면 됨.
-                    //         Expanded(
-                    //           child: ListView.builder(
-                    //             scrollDirection: Axis.horizontal,
-                    //             itemCount: 5,
-                    //             itemBuilder: (context, index) {
-                    //               return announce_tag_widget(index);
-                    //             },
-                    //           ),
-                    //         )
-                    //       ],
-                    //     ),
-                    //   ),
-                    // ),
-                    // Padding(
-                    //   padding: EdgeInsets.fromLTRB(20, 0, 20, 0),
-                    //   child: Divider(thickness: 1, color: Colors.grey),
-                    // ),
+                      //토픽
+                      //지우셔도 됩니다.
+                      // Stack(children: [
+                      //   Container(
+                      //     height: 30,
+                      //     child: Center(
+                      //       child: ListView.separated(
+                      //         shrinkWrap: true,
+                      //         separatorBuilder: (context, index) {
+                      //           return Text(
+                      //             '|',
+                      //             style: TextStyle(fontSize: 14),
+                      //           );
+                      //         },
+                      //         itemCount: announce_topic_name.length,
+                      //         scrollDirection: Axis.horizontal,
+                      //         itemBuilder: (context, index) {
+                      //           return GestureDetector(
+                      //             onTap: () {
+                      //               setState(() {
+                      //                 notice_screen_topic_num = index;
+                      //               });
+                      //               print(index);
+                      //             },
+                      //             child: Padding(
+                      //               padding: EdgeInsets.fromLTRB(5, 0, 5, 0),
+                      //               child: Text(
+                      //                 announce_topic_name[index],
+                      //                 style: TextStyle(
+                      //                     fontSize: 14,
+                      //                     fontWeight:
+                      //                         (index == notice_screen_topic_num)
+                      //                             ? FontWeight.bold
+                      //                             : FontWeight.normal),
+                      //               ),
+                      //             ),
+                      //           );
+                      //         },
+                      //       ),
+                      //     ),
+                      //   ),
+                      //   Align(
+                      //     alignment: Alignment.centerRight,
+                      //     child: Padding(
+                      //       padding: const EdgeInsets.fromLTRB(0, 2.5, 10, 0),
+                      //       child: GestureDetector(
+                      //           child: Text('추가하기',
+                      //               style: TextStyle(
+                      //                   color: Colors.black38,
+                      //                   fontWeight: FontWeight.bold,
+                      //                   fontSize: 11)),
+                      //           onTap: () {}),
+                      //     ),
+                      //   )
+                      // ]),
+                      // //검색창
+                      // Container(
+                      //     padding: EdgeInsets.fromLTRB(8, 0, 8, 0),
+                      //     decoration: BoxDecoration(
+                      //       color: Colors.grey.shade200,
+                      //       borderRadius: BorderRadius.circular(20),
+                      //     ),
+                      //     width: MediaQuery.of(context).size.width * 0.87,
+                      //     height: 35,
+                      //     margin: EdgeInsets.fromLTRB(0, 0, 0, 3),
+                      //     child: Row(
+                      //       crossAxisAlignment: CrossAxisAlignment.center,
+                      //       children: [
+                      //         Icon(Icons.search, size: 19),
+                      //         Expanded(
+                      //           child: Padding(
+                      //             padding: const EdgeInsets.fromLTRB(5, 0, 0, 0),
+                      //             child: TextField(
+                      //               controller: _controller,
+                      //               style: TextStyle(
+                      //                   fontSize: 15,
+                      //                   fontWeight: FontWeight.bold),
+                      //               decoration: InputDecoration(
+                      //                   hintText: '검색어를 입력해주세요',
+                      //                   border: InputBorder.none,
+                      //                   hintStyle:
+                      //                       TextStyle(color: Colors.black12)),
+                      //             ),
+                      //           ),
+                      //         ),
+                      //         GestureDetector(
+                      //             onTap: () {
+                      //               setState(() {
+                      //                 print(1);
+                      //                 _controller?.text = '';
+                      //                 //포커스 해제
+                      //                 FocusManager.instance.primaryFocus
+                      //                     ?.unfocus();
+                      //               });
+                      //             },
+                      //             child: Icon(Icons.cancel_outlined, size: 17)),
+                      //       ],
+                      //     )),
+                      // Container(
+                      //   height: 37,
+                      //   width: 400,
+                      //   child: Padding(
+                      //     padding: EdgeInsets.fromLTRB(23, 8, 0, 4),
+                      //     child: Row(
+                      //       mainAxisAlignment: MainAxisAlignment.center,
+                      //       crossAxisAlignment: CrossAxisAlignment.center,
+                      //       children: [
+                      //         //index에 따라 api에서 가져온 값 넣어주면 됨.
+                      //         Expanded(
+                      //           child: ListView.builder(
+                      //             scrollDirection: Axis.horizontal,
+                      //             itemCount: 5,
+                      //             itemBuilder: (context, index) {
+                      //               return announce_tag_widget(index);
+                      //             },
+                      //           ),
+                      //         )
+                      //       ],
+                      //     ),
+                      //   ),
+                      // ),
+                      // Padding(
+                      //   padding: EdgeInsets.fromLTRB(20, 0, 20, 0),
+                      //   child: Divider(thickness: 1, color: Colors.grey),
+                      // ),
 
-                    // //각각 widget 형성된걸로 넣어줌. 하나의 예시일뿐 api에 따라 listview처리 해줘야함.
-                    // //Container의 height, width, Expanded의 처리가 까다로움 주의.
-                    // sss(),
-                    // sss(),
-                    // //아래 빠르게 바로가기 코드입니다. 화살표에 따라 값 변경, 값 선택에 따른 내부 값 처리까지 다 해놨습니다.
-                    // Align(
-                    //   alignment: Alignment.bottomCenter,
-                    //   child: Row(
-                    //     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    //     children: [
-                    //       GestureDetector(
-                    //         onTap: () {
-                    //           setState(() {
-                    //             (min_list_num != 1)
-                    //                 ? min_list_num--
-                    //                 : min_list_num;
-                    //           });
-                    //         },
-                    //         child: Text(
-                    //           '< ',
-                    //           style: TextStyle(
-                    //             fontSize: 20,
-                    //           ),
-                    //         ),
-                    //       ),
-                    //       Container(
-                    //         height: 35,
-                    //         width: 300,
-                    //         child: ListView.builder(
-                    //           scrollDirection: Axis.horizontal,
-                    //           itemCount: 9,
-                    //           itemBuilder: (context, index) {
-                    //             return Card(
-                    //               color: Colors.white,
-                    //               shadowColor: Colors.white,
-                    //               child: Container(
-                    //                 color: Colors.white,
-                    //                 width: (MediaQuery.of(context).size.width -
-                    //                         30.4) *
-                    //                     0.069,
-                    //                 child: GestureDetector(
-                    //                   onTap: () {
-                    //                     setState(() {
-                    //                       current_list_num =
-                    //                           index + min_list_num - 1;
-                    //                     });
-                    //                     print(index);
-                    //                   },
-                    //                   child: Text(
-                    //                     (min_list_num + index).toString(),
-                    //                     style: TextStyle(
-                    //                       fontSize: 20,
-                    //                       fontWeight: current_list_num ==
-                    //                               (min_list_num + index - 1)
-                    //                           ? FontWeight.bold
-                    //                           : FontWeight.normal,
-                    //                     ),
-                    //                   ),
-                    //                 ),
-                    //               ),
-                    //             );
-                    //           },
-                    //         ),
-                    //       ),
-                    //       GestureDetector(
-                    //         onTap: () {
-                    //           setState(() {
-                    //             min_list_num++;
-                    //           });
-                    //         },
-                    //         child: Text(' >',
-                    //             style: TextStyle(
-                    //               fontSize: 20,
-                    //             )),
-                    //       ),
-                    //     ],
-                    //   ),
-                    // )
-                  ],
+                      // //각각 widget 형성된걸로 넣어줌. 하나의 예시일뿐 api에 따라 listview처리 해줘야함.
+                      // //Container의 height, width, Expanded의 처리가 까다로움 주의.
+                      // sss(),
+                      // sss(),
+                      // //아래 빠르게 바로가기 코드입니다. 화살표에 따라 값 변경, 값 선택에 따른 내부 값 처리까지 다 해놨습니다.
+                      // Align(
+                      //   alignment: Alignment.bottomCenter,
+                      //   child: Row(
+                      //     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      //     children: [
+                      //       GestureDetector(
+                      //         onTap: () {
+                      //           setState(() {
+                      //             (min_list_num != 1)
+                      //                 ? min_list_num--
+                      //                 : min_list_num;
+                      //           });
+                      //         },
+                      //         child: Text(
+                      //           '< ',
+                      //           style: TextStyle(
+                      //             fontSize: 20,
+                      //           ),
+                      //         ),
+                      //       ),
+                      //       Container(
+                      //         height: 35,
+                      //         width: 300,
+                      //         child: ListView.builder(
+                      //           scrollDirection: Axis.horizontal,
+                      //           itemCount: 9,
+                      //           itemBuilder: (context, index) {
+                      //             return Card(
+                      //               color: Colors.white,
+                      //               shadowColor: Colors.white,
+                      //               child: Container(
+                      //                 color: Colors.white,
+                      //                 width: (MediaQuery.of(context).size.width -
+                      //                         30.4) *
+                      //                     0.069,
+                      //                 child: GestureDetector(
+                      //                   onTap: () {
+                      //                     setState(() {
+                      //                       current_list_num =
+                      //                           index + min_list_num - 1;
+                      //                     });
+                      //                     print(index);
+                      //                   },
+                      //                   child: Text(
+                      //                     (min_list_num + index).toString(),
+                      //                     style: TextStyle(
+                      //                       fontSize: 20,
+                      //                       fontWeight: current_list_num ==
+                      //                               (min_list_num + index - 1)
+                      //                           ? FontWeight.bold
+                      //                           : FontWeight.normal,
+                      //                     ),
+                      //                   ),
+                      //                 ),
+                      //               ),
+                      //             );
+                      //           },
+                      //         ),
+                      //       ),
+                      //       GestureDetector(
+                      //         onTap: () {
+                      //           setState(() {
+                      //             min_list_num++;
+                      //           });
+                      //         },
+                      //         child: Text(' >',
+                      //             style: TextStyle(
+                      //               fontSize: 20,
+                      //             )),
+                      //       ),
+                      //     ],
+                      //   ),
+                      // )
+                    ],
+                  ),
                 ),
               ),
             )),
@@ -424,6 +440,7 @@ class noticeView extends StatelessWidget {
         color: Colors.white,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(10),
+          side: BorderSide(color: Color(0xFFBBBBBB), width: 1), // 여기서 변경
         ),
       ),
       child: Column(
@@ -463,7 +480,7 @@ class noticeView extends StatelessWidget {
                           Navigator.push(
                             context,
                             MaterialPageRoute(
-                                builder: (context) => NoticeScreenDetail()),
+                                builder: (context) => NoticeScreenFavorite()),
                           );
                         } else {
                           Navigator.push(
@@ -490,7 +507,10 @@ class noticeView extends StatelessWidget {
                     subtitle: Text(notice['category'] ?? ''),
                     onTap: () {
                       print('Clicked on ${notice['title']}');
-                      Navigator.push(context, MaterialPageRoute(builder: (context) => notice_screen_page()));
+                      Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                              builder: (context) => notice_screen_page()));
                       // Navigator.push(
                       //   context,
                       //   MaterialPageRoute(

--- a/lib/view/notice_screen_detail.dart
+++ b/lib/view/notice_screen_detail.dart
@@ -216,12 +216,12 @@ class _NoticeScreenDetailState extends State<NoticeScreenDetail> {
             child: Padding(
               padding: EdgeInsets.fromLTRB(23, 8, 0, 4),
               child: //index에 따라 api에서 가져온 값 넣어주면 됨.
-                    ListView.builder(
-                      scrollDirection: Axis.horizontal,
-                      itemCount: 6,
-                      itemBuilder: (context, index) {
-                        return announce_tag_widget(index);
-                      },
+                  ListView.builder(
+                scrollDirection: Axis.horizontal,
+                itemCount: 6,
+                itemBuilder: (context, index) {
+                  return announce_tag_widget(index);
+                },
               ),
             ),
           ),
@@ -247,135 +247,145 @@ class DatenoticeView extends StatelessWidget {
   }) : super(key: key);
   @override
   Widget build(BuildContext context) {
-    return Container(
-      margin: EdgeInsets.only(bottom: 10),
-      width: MediaQuery.of(context).size.width * 0.9,
-      padding: const EdgeInsets.only(top: 15, right: 0.99),
-      decoration: ShapeDecoration(
-        color: Colors.white,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(10),
+    return SafeArea(
+      child: Container(
+        margin: EdgeInsets.only(bottom: 10),
+        width: MediaQuery.of(context).size.width * 0.9,
+        padding: const EdgeInsets.only(top: 15, right: 0.99),
+        decoration: ShapeDecoration(
+          color: Colors.white,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(10),
+          ),
         ),
-      ),
-      child: Column(
-        children: [
-          // Row(
-          //   mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          //   children: [
-          //     Row(
-          //       children: [
-          //         Text(
-          //           title,
-          //           style: TextStyle(
-          //             color: Colors.black,
-          //             fontSize: 14,
-          //             fontFamily: 'Inter',
-          //             fontWeight: FontWeight.w700,
-          //             height: 0,
-          //           ),
-          //         ),
-          //       ],
-          //     ),
-          //     Row(
-          //       children: [
-          //         Text(
-          //           '더 보기',
-          //           style: TextStyle(
-          //             color: Colors.black,
-          //             fontSize: 12,
-          //             fontFamily: 'Inter',
-          //             fontWeight: FontWeight.w400,
-          //             height: 0,
-          //           ),
-          //         ),
-          //         IconButton(
-          //             onPressed: () {
-          //               Navigator.push(
-          //                 context,
-          //                 MaterialPageRoute(
-          //                     builder: (context) => NoticeScreenDetail()),
-          //               );
-          //             },
-          //             icon: Icon(Icons.arrow_right)),
-          //       ],
-          //     ),
-          //   ],
-          // ),
-          Container(
-            height: 600,
-            color: Colors.white,
-            child: ListView.builder(
-              itemCount: dateNoticeData.length,
-              itemBuilder: (context, index) {
-                final dateKey = dateNoticeData.keys.elementAt(index);
-                final noticeList = dateNoticeData[dateKey] ?? {}; // null 체크 추가
-                return Card(
-                  child: Container(
-                    color: Colors.white,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: Text(
-                            dateKey,
-                            style: TextStyle(
-                              fontSize: 20,
-                              fontWeight: FontWeight.bold,
+        child: Column(
+          children: [
+            // Row(
+            //   mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            //   children: [
+            //     Row(
+            //       children: [
+            //         Text(
+            //           title,
+            //           style: TextStyle(
+            //             color: Colors.black,
+            //             fontSize: 14,
+            //             fontFamily: 'Inter',
+            //             fontWeight: FontWeight.w700,
+            //             height: 0,
+            //           ),
+            //         ),
+            //       ],
+            //     ),
+            //     Row(
+            //       children: [
+            //         Text(
+            //           '더 보기',
+            //           style: TextStyle(
+            //             color: Colors.black,
+            //             fontSize: 12,
+            //             fontFamily: 'Inter',
+            //             fontWeight: FontWeight.w400,
+            //             height: 0,
+            //           ),
+            //         ),
+            //         IconButton(
+            //             onPressed: () {
+            //               Navigator.push(
+            //                 context,
+            //                 MaterialPageRoute(
+            //                     builder: (context) => NoticeScreenDetail()),
+            //               );
+            //             },
+            //             icon: Icon(Icons.arrow_right)),
+            //       ],
+            //     ),
+            //   ],
+            // ),
+            Container(
+              height: 600,
+              color: Colors.white,
+              child: ListView.builder(
+                itemCount: dateNoticeData.length,
+                itemBuilder: (context, index) {
+                  final dateKey = dateNoticeData.keys.elementAt(index);
+                  final noticeList =
+                      dateNoticeData[dateKey] ?? {}; // null 체크 추가
+                  return Card(
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10),
+                      side: BorderSide(
+                          color: Color(0xFFBBBBBB),
+                          width: 1), // 여기서 테두리 색상 및 두께를 변경하세요
+                    ),
+                    child: Container(
+                      color: Colors.white,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Padding(
+                            padding: const EdgeInsets.all(8.0),
+                            child: Text(
+                              dateKey,
+                              style: TextStyle(
+                                fontSize: 20,
+                                fontWeight: FontWeight.bold,
+                              ),
                             ),
                           ),
-                        ),
-                        ListView.builder(
-                          shrinkWrap: true,
-                          physics: NeverScrollableScrollPhysics(),
-                          itemCount: noticeList?.length ?? 0, // null 체크 추가
-                          itemBuilder: (context, index) {
-                            final noticeKey = noticeList.keys.elementAt(index);
-                            final noticeData = noticeList[noticeKey];
-                            return ListTile(
-                              tileColor: Colors.white,
-                              title: Text(noticeData?['title'] ?? ''),
-                              subtitle: Text(noticeData?['category'] ?? ''),
-                              onTap: () {
-                                // Handle tap event
-                              },
-                            );
-                          },
-                        ),
-                      ],
+                          ListView.builder(
+                            shrinkWrap: true,
+                            physics: NeverScrollableScrollPhysics(),
+                            itemCount: noticeList?.length ?? 0, // null 체크 추가
+                            itemBuilder: (context, index) {
+                              final noticeKey =
+                                  noticeList.keys.elementAt(index);
+                              final noticeData = noticeList[noticeKey];
+                              return ListTile(
+                                tileColor: Colors.white,
+                                title: Text(noticeData?['title'] ?? ''),
+                                subtitle: Text(noticeData?['category'] ?? ''),
+                                onTap: () {
+                                  // Handle tap event
+                                },
+                              );
+                            },
+                          ),
+                        ],
+                      ),
                     ),
-                  ),
-                );
-              },
-            ),
-          )
-          // Container(
-          //   height: 300,
-          //   child: ListView.builder(
-          //     itemCount: noticeData.length,
-          //     itemBuilder: (context, index) {
-          //       final notice = noticeData[index.toString()];
-          //       if (notice != null) {
-          //         return ListTile(
-          //           title: Text(notice['title'] ?? ''),
-          //           subtitle: Text(notice['category'] ?? ''),
-          //           onTap: () {
-          //             print('Clicked on ${notice['title']}');
-          //             // Navigator.push(
-          //             //   context,
-          //             //   MaterialPageRoute(
-          //             //     builder: (context) => WebViewScreen(url: notice['link'] ?? ''),
-          //             //   ),
-          //             // );
-          //           },
-          //         );
-          //       } else {
-          //         return SizedBox(); // 에러를 피하기 위해 빈 위젯을 반환합니다.
-          //       }
-          //     },
-          //   ),
-          // ),
-        ],
+                  );
+                },
+              ),
+            )
+            // Container(
+            //   height: 300,
+            //   child: ListView.builder(
+            //     itemCount: noticeData.length,
+            //     itemBuilder: (context, index) {
+            //       final notice = noticeData[index.toString()];
+            //       if (notice != null) {
+            //         return ListTile(
+            //           title: Text(notice['title'] ?? ''),
+            //           subtitle: Text(notice['category'] ?? ''),
+            //           onTap: () {
+            //             print('Clicked on ${notice['title']}');
+            //             // Navigator.push(
+            //             //   context,
+            //             //   MaterialPageRoute(
+            //             //     builder: (context) => WebViewScreen(url: notice['link'] ?? ''),
+            //             //   ),
+            //             // );
+            //           },
+            //         );
+            //       } else {
+            //         return SizedBox(); // 에러를 피하기 위해 빈 위젯을 반환합니다.
+            //       }
+            //     },
+            //   ),
+            // ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/view/notice_screen_favorite.dart
+++ b/lib/view/notice_screen_favorite.dart
@@ -3,14 +3,14 @@ import 'package:myapp/view/notice_screen_detail.dart';
 
 import '../component/announce_tag.dart';
 
-class NoticeScreenSimilar extends StatefulWidget {
-  const NoticeScreenSimilar({super.key});
+class NoticeScreenFavorite extends StatefulWidget {
+  const NoticeScreenFavorite({super.key});
 
   @override
-  State<NoticeScreenSimilar> createState() => _NoticeScreenSimilarState();
+  State<NoticeScreenFavorite> createState() => _NoticeScreenFavoriteState();
 }
 
-class _NoticeScreenSimilarState extends State<NoticeScreenSimilar> {
+class _NoticeScreenFavoriteState extends State<NoticeScreenFavorite> {
   List<String> announce_topic_name = ['인하대학교', 'SW중심대학', '컴퓨터공학'];
   int min_list_num = 1;
   int current_list_num = 0;
@@ -46,7 +46,7 @@ class _NoticeScreenSimilarState extends State<NoticeScreenSimilar> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text("비슷한 사용자가 본 공지사항"),
+        title: Text("즐겨찾기"),
       ),
       body: SafeArea(
         child: Column(
@@ -79,7 +79,7 @@ class _NoticeScreenSimilarState extends State<NoticeScreenSimilar> {
               padding: EdgeInsets.fromLTRB(20, 0, 20, 0),
               child: Divider(thickness: 1, color: Colors.grey),
             ),
-            noticeView(
+            favoriteNoticeView(
               noticeData: _SimilarNoticeData,
             )
           ],
@@ -145,7 +145,7 @@ class DatenoticeView extends StatelessWidget {
           //               Navigator.push(
           //                 context,
           //                 MaterialPageRoute(
-          //                     builder: (context) => NoticeScreenSimilar()),
+          //                     builder: (context) => NoticeScreenFavorite()),
           //               );
           //             },
           //             icon: Icon(Icons.arrow_right)),
@@ -233,10 +233,10 @@ class DatenoticeView extends StatelessWidget {
   }
 }
 
-class noticeView extends StatelessWidget {
+class favoriteNoticeView extends StatelessWidget {
   final Map<String, Map<String, String>> noticeData;
 
-  const noticeView({
+  const favoriteNoticeView({
     Key? key,
     required this.noticeData,
   }) : super(key: key);

--- a/lib/widget/home_notice_view.dart
+++ b/lib/widget/home_notice_view.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+class homeNoticeView extends StatelessWidget {
+  final Map<String, Map<String, String>> noticeData;
+
+  const homeNoticeView({
+    Key? key,
+    required this.noticeData,
+  }) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: EdgeInsets.only(bottom: 10),
+      width: MediaQuery.of(context).size.width * 0.9,
+      padding: const EdgeInsets.only(top: 15, right: 0.99),
+      decoration: ShapeDecoration(
+        color: Colors.white,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10),
+        ),
+      ),
+      child: Column(
+        children: [
+          Container(
+            height: 210,
+            child: ListView.builder(
+              itemCount: noticeData.length,
+              itemBuilder: (context, index) {
+                final notice = noticeData[index.toString()];
+                if (notice != null) {
+                  return ListTile(
+                    title: Text(notice['title'] ?? ''),
+                    subtitle: Text(notice['category'] ?? ''),
+                    onTap: () {
+                      print('Clicked on ${notice['title']}');
+                      // Navigator.push(
+                      //   context,
+                      //   MaterialPageRoute(
+                      //     builder: (context) => WebViewScreen(url: notice['link'] ?? ''),
+                      //   ),
+                      // );
+                    },
+                  );
+                } else {
+                  return SizedBox(); // 에러를 피하기 위해 빈 위젯을 반환합니다.
+                }
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widget/list_view.dart
+++ b/lib/widget/list_view.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+class LineListView extends StatelessWidget {
+  final List<List<String>> itemList;
+  final List<Future<void> Function()>? onTap;
+  final double fontSize;
+  final double itemSpacing;
+  final EdgeInsetsGeometry padding;
+
+  const LineListView({
+    Key? key,
+    required this.itemList,
+    required this.onTap,
+    this.fontSize = 20,
+    this.itemSpacing = 8.0,
+    this.padding = const EdgeInsets.all(14.0),
+  }) : super(key: key);
+
+  void _onTapHandler(int index) async {
+    if (onTap != null) await onTap![index](); // null 예외 처리
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: itemList.length,
+      itemBuilder: (BuildContext context, int index) {
+        final item = itemList[index];
+
+        Widget textWidget;
+        if (item.length == 2) {
+          textWidget = Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                item[0],
+                style: TextStyle(fontSize: fontSize),
+              ),
+              Text(
+                item[1],
+                style: TextStyle(fontSize: fontSize),
+              ),
+            ],
+          );
+        } else {
+          textWidget = Text(
+            item[0],
+            style: TextStyle(fontSize: fontSize),
+          );
+        }
+
+        return GestureDetector(
+          onTap: () {
+            _onTapHandler(index);
+          },
+          child: Padding(
+            padding:
+                EdgeInsets.symmetric(vertical: itemSpacing, horizontal: 15),
+            child: Container(
+              child: Padding(
+                padding: padding,
+                child: textWidget,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -672,30 +672,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
-  leak_tracker:
-    dependency: transitive
-    description:
-      name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.0.4"
-  leak_tracker_flutter_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.3"
-  leak_tracker_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -716,26 +692,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.10.0"
   mime:
     dependency: transitive
     description:
@@ -788,10 +764,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.3"
   path_parsing:
     dependency: transitive
     description:
@@ -1041,10 +1017,10 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "3da423ce7baf868be70e2c0976c28a1bb2f73644268b7ffa7d2e08eab71f16a4"
+      sha256: "28d8c66baee4968519fb8bd6cdbedad982d6e53359091f0b74544a9f32ec72d5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "2.5.3"
   stack_trace:
     dependency: transitive
     description:
@@ -1113,10 +1089,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.6.1"
   typed_data:
     dependency: transitive
     description:
@@ -1265,18 +1241,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_web
-      sha256: "8e9cb7fe94e49490e67bbc15149691792b58a0ade31b32e3f3688d104a0e057b"
+      sha256: "34beb3a07d4331a24f7e7b2f75b8e2b103289038e07e65529699a671b6a6e2cb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
-  vm_service:
-    dependency: transitive
-    description:
-      name: vm_service
-      sha256: a2662fb1f114f4296cf3f5a50786a2d888268d7776cf681aa17d660ffa23b246
-      url: "https://pub.dev"
-    source: hosted
-    version: "14.0.0"
+    version: "2.1.3"
   wakelock_plus:
     dependency: transitive
     description:
@@ -1358,5 +1326,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  dart: ">=3.2.3 <4.0.0"
+  flutter: ">=3.16.6"


### PR DESCRIPTION
<img width="371" alt="image" src="https://github.com/INfoU-INHA-for-U/INfoU/assets/72590336/549822ac-62f2-4a09-871c-98fa6dd0a812">

1. 홈 페이지의 디자인 변경에 따라 수정했습니다.
공지사항과 강의평가 페이지에서 쓰이는 위젯들이 쓰이고 있는데, 
정민님이 제작한 _current_evaluate_data 위젯은 재사용하지 못하고 있는 상태입니다.
widget 란에 저장하여 재사용하도록 리팩토링해주시면 감사하겠습니다.

<img width="371" alt="image" src="https://github.com/INfoU-INHA-for-U/INfoU/assets/72590336/1a79025e-d91e-454c-838a-a5cc8f2f9cbe">

2. 마이페이지 란 구현했습니다.
해당 페이지에서 쓰이는 파란색 카드는 MyPageCard 위젯으로 정의해 놓았습니다.


3. 우측 상단 설정 mypage_screen_setting 페이지 입니다.

<img width="372" alt="image" src="https://github.com/INfoU-INHA-for-U/INfoU/assets/72590336/e99b0fbd-2e09-4c58-b092-aa7de7a36b0f">

마찬가지로 LineListView 위젯으로 구현해 놓았고, 
해당 부분에서 '사용자 정보변경' 으로 들어가면 처음 회원가입 페이지가 나옵니다. 해당 스크린 재활용하면 좋을 것 같고 페이지 이동시 앱바 title 을 파라미터로 받아 들어가면 좋겠습니다.

다른 부분은 페이지만 만들면 들어갈 수 있게 구현처리해놓았습니다. (현재는 공란)

4. 포인트확인 mypage_screen_point 페이지 입니다

<img width="367" alt="image" src="https://github.com/INfoU-INHA-for-U/INfoU/assets/72590336/81afb17b-186f-4c1d-a343-4eff7ce5f5e8">

---

따라서 마이페이지에서는 즐겨찾는학과 만 추가 구현하면 되겠습니다만, 이것도 기존의 페이지에서 가져올 수 있지 않나 싶네요
